### PR TITLE
Removes <engines /> element to allow use with phonegap rather than cordova

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,10 +11,6 @@
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-inappbrowser.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320641</issue>
 
-    <engines>
-      <engine name="cordova" version=">=3.1.0" /><!-- Needs cordova/urlutil -->
-    </engines>
-
     <js-module src="www/InAppBrowser.js" name="InAppBrowser">
         <clobbers target="window.open" />
     </js-module>


### PR DESCRIPTION
When using **[phonegap-cli](https://github.com/phonegap/phonegap-cli)** (and all other engines besides **cordova**), this plugin is quietly excluded due to this restrictive <engine /> element.
