### PR TITLE
Fix to restore previous status bar style (iOS7+)

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -398,11 +398,11 @@
     // Also - this is required for the PDF/User-Agent bug work-around.
     self.inAppBrowserViewController = nil;
         
-    _previousStatusBarStyle = -1;
-
     if (IsAtLeastiOSVersion(@"7.0")) {
         [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
     }
+
+    _previousStatusBarStyle = -1;
 }
 
 @end


### PR DESCRIPTION
 Fix to restore previous status bar style (iOS7+) when in-app browser is closed.
