### PR TITLE
window.open failing without options parameter

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -53,7 +53,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             string target = args[1];
             string featString = args[2];
 
-            string[] features = featString.Split(',');
+            string[] features = (featString != null) ? featString.Split(',') : new string[0];
             foreach (string str in features)
             {
                 try


### PR DESCRIPTION
Documentation indicates options parameter for window.open() is optional, but omitting the parameter on WP8 crashes calls to window.open. Has regressed, so may break existing projects that depend on this plugin.
