### PR TITLE
Fix no such file or directory for inappbrowser.js

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
     
     <!-- android -->
     <platform name="android">
-        <js-module src="www/inappbrowser.js" name="inappbrowser">
+        <js-module src="www/InAppBrowser.js" name="inappbrowser">
             <clobbers target="window.open" />
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
I was trying to install this plugin with

```
cordova plugin add org.apache.cordova.inappbrowser
```

but there was an error:

```
Fetching plugin "org.apache.cordova.inappbrowser" via plugin registry
Starting installation of "org.apache.cordova.inappbrowser" for android
Preparing android project
Error: ENOENT, no such file or directory '/home/user/projects/cordova-test/plugins/org.apache.cordova.inappbrowser/www/inappbrowser.js'
    at Object.fs.openSync (fs.js:432:18)
    at Object.fs.readFileSync (fs.js:286:15)
    at /usr/local/lib/node_modules/cordova/node_modules/plugman/src/prepare.js:165:40
    at Array.forEach (native)
    at /usr/local/lib/node_modules/cordova/node_modules/plugman/src/prepare.js:145:24
    at Array.forEach (native)
    at Object.handlePrepare (/usr/local/lib/node_modules/cordova/node_modules/plugman/src/prepare.js:123:24)
    at /usr/local/lib/node_modules/cordova/node_modules/plugman/src/install.js:383:33
    at _fulfilled (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:798:54)
    at self.promiseDispatch.done (/usr/local/lib/node_modules/cordova/node_modules/q/q.js:827:30)
```

I noticed that the file was there but its name wasnt `inappbrowser.js` but `InAppBrowser.js`.

I've forked the repository and changed the file name in plugin.xml, then I was able to install the plugin without an issue and it seems to work fine so far.
