### PR TITLE
Add necessary capability so the plugin works on its own

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -102,6 +102,10 @@
             </feature>
         </config-file>
 
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_NETWORKING" />
+        </config-file>
+
         <source-file src="src/wp/InAppBrowser.cs" />
     </platform>
 
@@ -114,6 +118,10 @@
             <feature name="InAppBrowser">
                 <param name="wp-package" value="InAppBrowser"/>
             </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_NETWORKING" />
         </config-file>
 
         <source-file src="src/wp/InAppBrowser.cs" />


### PR DESCRIPTION
If the plugin is installed on clean Cordova project with no other plugins enabled, it needs the ID_CAP_NETWORKING capability enabled in order to work. Both for wp8 and wp7.

https://issues.apache.org/jira/browse/CB-6380
