### PR TITLE
CB-6360: Fix for crash on iOS < 6.0

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -529,7 +529,11 @@
     self.addressLabel.enabled = YES;
     self.addressLabel.hidden = NO;
     self.addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-    self.addressLabel.minimumScaleFactor = 10.000;
+    if (IsAtLeastiOSVersion(@"6.0")) {
+        self.addressLabel.minimumScaleFactor = 10.0/[UIFont labelFontSize];
+    } else {
+        self.addressLabel.minimumFontSize = 10.000;
+    }
     self.addressLabel.multipleTouchEnabled = NO;
     self.addressLabel.numberOfLines = 1;
     self.addressLabel.opaque = NO;


### PR DESCRIPTION
CB-6360: Fix for crash on iOS < 6.0, as described at https://issues.apache.org/jira/browse/CB-6360
