### PR TITLE
window.open(url, '_system') does work now

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -51,7 +51,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             //BrowserOptions opts = JSON.JsonHelper.Deserialize<BrowserOptions>(options);
             string urlLoc = args[0];
             string target = args[1];
-            string featString = args[2];
+            string featString = args[2] != null ? args[2] : "";
 
             string[] features = featString.Split(',');
             foreach (string str in features)


### PR DESCRIPTION
Checking the variable `featString` for null value.
If third parameter of `window.open()` is not used, the method fails at `featString.Split(',')` because featString is null.
This was the reason why `window.open()` with target `_system` did not work on Windows Phone.
