### PR TITLE
FirefoxOS Tweak: Setting zIndex Value

### DIFF
--- a/src/firefoxos/InAppBrowserProxy.js
+++ b/src/firefoxos/InAppBrowserProxy.js
@@ -69,6 +69,7 @@ var IABExecs = {
             browserWrap.style.width = window.innerWidth + 'px';
             browserWrap.style.height = window.innerHeight + 'px';
             browserWrap.style.padding = '10px,0,0,0';
+            browserWrap.style.zIndex = '999999999';
             browserElem.style.position = 'absolute';
             browserElem.style.top = '60px';
             browserElem.style.left = '0px';


### PR DESCRIPTION
The current inappbrowser creation takes place at zIndex auto which
doesn’t work with a large variety of code bases and various User
Interface Systems
