### PR TITLE
Fix opening of files in Windows Phone 8.

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -239,7 +239,16 @@ namespace WPCordovaClassLib.Cordova.Commands
                 return;
             }
 
-            var file = await GetFile(pathUri.AbsolutePath.Replace('/', Path.DirectorySeparatorChar));
+            // Remove x-wmapp0 protocol, making this a relative URL, keeping the original path
+            const string IsolatedStorageProtocol = "x-wmapp0://";
+            if (url.StartsWith(IsolatedStorageProtocol, StringComparison.OrdinalIgnoreCase))
+            {
+                url = url.Substring(IsolatedStorageProtocol.Length);
+            }
+            url = url.Replace('/', Path.DirectorySeparatorChar);
+            url = url.Trim(Path.DirectorySeparatorChar); // Remove trailing and leading path separator chars
+
+            var file = await GetFile(url);
             if (file != null)
             {
                 await Launcher.LaunchFileAsync(file);


### PR DESCRIPTION
The files weren't being opened, because of UriKind.Absolute.

For example: entry.toNativeURL() results in "x-wmapp0://example.pdf/".
Using the existing code, "pathUri.AbsolutePath" results in "/" (because that is the path of the above URL).
And that is definitely NOT the URL we wanted to open...

The code now checks this, reformats the URL and eventually uses the supplied URL to open the file.
