### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/InAppBrowserProxy.js
+++ b/src/firefoxos/InAppBrowserProxy.js
@@ -168,4 +168,4 @@ var IABExecs = {
 
 module.exports = IABExecs;
 
-require('cordova/firefoxos/commandProxy').add('InAppBrowser', module.exports);
+require('cordova/exec/proxy').add('InAppBrowser', module.exports);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
