### PR TITLE
Hide status bar in iOS 7 with option

### DIFF
--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -58,6 +58,7 @@
 @property (nonatomic, assign) BOOL suppressesincrementalrendering;
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL disallowoverscroll;
+@property (nonatomic, assign) BOOL hidestatusbar;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -723,6 +723,10 @@
     [super viewDidLoad];
 }
 
+- (BOOL)prefersStatusBarHidden{
+    return _browserOptions.hidestatusbar;
+}
+
 - (void)viewDidUnload
 {
     [self.webView loadHTMLString:nil baseURL:nil];


### PR DESCRIPTION
This minor change allows you to use an option "hidestatusbar=yes" to hide the status bar in IOS 7. It implements the perferStatusBarHidden method. It defaults to NO, so that functionality does not change.
