### PR TITLE
CB-7608 : add option useWidthViewPort (Android Platform) 

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -88,6 +88,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String MEDIA_PLAYBACK_REQUIRES_USER_ACTION = "mediaPlaybackRequiresUserAction";
     private static final String SHOULD_PAUSE = "shouldPauseOnSuspend";
     private static final Boolean DEFAULT_HARDWARE_BACK = true;
+    private static final String USER_WIDE_VIEW_PORT = "useWideViewPort";
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -101,6 +102,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean hadwareBackButton = true;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
+    private boolean useWideViewPort = true;
 
     /**
      * Executes the request and returns PluginResult.
@@ -558,6 +560,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (shouldPause != null) {
                 shouldPauseInAppBrowser = shouldPause.booleanValue();
             }
+            Boolean wideViewPort = features.get(USER_WIDE_VIEW_PORT);
+            if (wideViewPort != null ) {
+		            useWideViewPort = wideViewPort.booleanValue();
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -758,7 +764,7 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView.loadUrl(url);
                 inAppWebView.setId(Integer.valueOf(6));
                 inAppWebView.getSettings().setLoadWithOverviewMode(true);
-                inAppWebView.getSettings().setUseWideViewPort(true);
+                inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);
                 inAppWebView.requestFocus();
                 inAppWebView.requestFocusFromTouch();
 


### PR DESCRIPTION
When using inAppBrowser with Android, the viewport tag of the loaded page is ignored. As a result, some pages using a specific viewport (for instance an Ionic view) are completly zoomed out.
With iOS it's possible to fix that by passing "enableViewportScale" but for Android the only way to fix this is to set 'useWideViewPort' to 'false' . It's now harcoded to 'true' https://github.com/apache/cordova-plugin-inappbrowser/blob/master/src/android/InAppBrowser.java#L620.
We should be able to pass the value through the option (i.e : 'location=no, useWideViewPort=no')
