### PR TITLE
hack: very bad fix but just works for fixing the dialog closing on Andro...

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -457,6 +457,9 @@ public class InAppBrowser extends CordovaPlugin {
             @SuppressLint("NewApi")
             public void run() {
                 // Let's create the main dialog
+                if (dialog != null) {
+                    dialog.dismiss();
+                }
                 dialog = new InAppBrowserDialog(cordova.getActivity(), android.R.style.Theme_NoTitleBar);
                 dialog.getWindow().getAttributes().windowAnimations = android.R.style.Animation_Dialog;
                 dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);


### PR DESCRIPTION
On Android, it's very frequent to fall into this bug : you cannot close the inappbrowser dialog when you click on the X button. The impact is massive because the user get stuck and cannot even go back to the app, so you can only kill the app...

I'm not so familiar with this code but I just can understand that there are multiple dialogs (new InAppBrowserDialog) that are created when only opening one URL => happens when there are many redirections when launching the first URL (ex: twitter.com).  So when you click on the close button, the code only close the latest created dialog (via dialog.dismiss()) but not all of them. 

That is why I added a very simple test that dismiss the previous dialog when you want to create new one.

This is not a clean fix but it just works. Please review and comment this pull request, because as I said before, the impact is huge for the users.

Thanks.
