### PR TITLE
On WP 8.0 `execScript` need to be used instead of `eval`.

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -144,7 +144,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             {
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {
-                    var res = browser.InvokeScript("eval", new string[] { args[0] });
+                    var res = InvokeScript(args[0]);
 
                     if (bCallback)
                     {
@@ -227,6 +227,18 @@ namespace WPCordovaClassLib.Cordova.Commands
 
                 }
             });
+        }
+
+        private object InvokeScript(string script)
+        {
+            const string functionName = "__getInvokeScriptResult";
+            if (System.Environment.OSVersion.Version.Major == 8 && System.Environment.OSVersion.Version.Minor == 0)
+            {
+                browser.InvokeScript("execScript", new string[] { String.Format("var {0} = function(){{ return ({1}); }};", functionName, script) });
+                return browser.InvokeScript(functionName);
+            }
+
+            return browser.InvokeScript("eval", new [] { script });
         }
 
 #if WP8


### PR DESCRIPTION
Executing `browser.InvokeScript("eval", new string[] { anyJsExpression })` on WP 8.0 ends up with an exception.
