### PR TITLE
CB 8467: provide hide() method to hide browser window without closing connection

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -152,6 +152,7 @@ The object returned from a call to `window.open`.
 - removeEventListener
 - close
 - show
+- hide
 - executeScript
 - insertCSS
 
@@ -266,11 +267,26 @@ The function is passed an `InAppBrowserEvent` object.
 - iOS
 - Windows 8 and 8.1
 
+## hide
+
+> Hides the InAppBrowser window. Calling this has no effect if the InAppBrowser was already hidden.
+
+    ref.hide();
+
+- __ref__: reference to the InAppBrowser window (`InAppBrowser`)
+
+### Supported Platforms
+
+- Amazon Fire OS
+- Android
+- iOS
+- Windows 8 and 8.1
+
 ### Quick Example
 
-    var ref = window.open('http://apache.org', '_blank', 'hidden=yes');
+    var ref = window.open('http://apache.org', '_blank');
     // some time later...
-    ref.show();
+    ref.hide();
 
 ## executeScript
 

--- a/src/amazon/InAppBrowser.java
+++ b/src/amazon/InAppBrowser.java
@@ -210,6 +210,17 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+        else if (action.equals("hide")) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.hide();
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
         else {
             return false;
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -235,6 +235,17 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+        else if (action.equals("hide")) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.hide();
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
         else {
             return false;
         }

--- a/src/firefoxos/InAppBrowserProxy.js
+++ b/src/firefoxos/InAppBrowserProxy.js
@@ -45,6 +45,10 @@ var IABExecs = {
         console.error('[FirefoxOS] show not implemented');
     },
 
+    hide: function (win, lose) {
+        console.error('[FirefoxOS] hide not implemented');
+    },
+
     open: function (win, lose, args) {
         var strUrl = args[0],
             target = args[1],

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -36,6 +36,7 @@
 - (void)close:(CDVInvokedUrlCommand*)command;
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command;
 - (void)show:(CDVInvokedUrlCommand*)command;
+- (void)hide:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -20,7 +20,6 @@
 #import "CDVInAppBrowser.h"
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/CDVUserAgentUtil.h>
-#import <Cordova/CDVJSON.h>
 
 #define    kInAppBrowserTargetSelf @"_self"
 #define    kInAppBrowserTargetSystem @"_system"
@@ -265,7 +264,8 @@
     }
 
     if (jsWrapper != nil) {
-        NSString* sourceArrayString = [@[source] JSONString];
+        NSData* jsonData = [NSJSONSerialization dataWithJSONObject:@[source] options:0 error:nil];
+        NSString* sourceArrayString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         if (sourceArrayString) {
             NSString* sourceString = [sourceArrayString substringWithRange:NSMakeRange(1, [sourceArrayString length] - 2)];
             NSString* jsToInject = [NSString stringWithFormat:jsWrapper, sourceString];

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -227,6 +227,30 @@
     });
 }
 
+- (void)hide:(CDVInvokedUrlCommand*)command
+{
+    if (self.inAppBrowserViewController == nil) {
+        NSLog(@"Tried to hide IAB after it was closed.");
+        return;
+
+
+    }
+    if (_previousStatusBarStyle == -1) {
+        NSLog(@"Tried to hide IAB while already hidden");
+        return;
+    }
+
+    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
+
+    // Run later to avoid the "took a long time" log message.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.inAppBrowserViewController != nil) {
+            _previousStatusBarStyle = -1;
+            [self.viewController dismissViewControllerAnimated:YES completion:nil];
+        }
+    });
+}
+
 - (void)openInCordovaWebView:(NSURL*)url withOptions:(NSString*)options
 {
     if ([self.commandDelegate URLIsWhitelisted:url]) {

--- a/src/ubuntu/inappbrowser.cpp
+++ b/src/ubuntu/inappbrowser.cpp
@@ -65,6 +65,10 @@ void Inappbrowser::show(int, int) {
     m_cordova->execQML("CordovaWrapper.global.inappbrowser.visible = true");
 }
 
+void Inappbrowser::hide(int, int) {
+    m_cordova->execQML("CordovaWrapper.global.inappbrowser.visible = false");
+}
+
 void Inappbrowser::close(int, int) {
     m_cordova->execQML("CordovaWrapper.global.inappbrowser.destroy()");
     this->callbackWithoutRemove(_eventCb, EXIT_EVENT);

--- a/src/ubuntu/inappbrowser.h
+++ b/src/ubuntu/inappbrowser.h
@@ -46,6 +46,7 @@ public:
 public slots:
     void open(int cb, int, const QString &url, const QString &windowName, const QString &windowFeatures);
     void show(int, int);
+    void hide(int, int);
     void close(int, int);
     void injectStyleFile(int cb, int, const QString&, bool);
     void injectStyleCode(int cb, int, const QString&, bool);

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -95,6 +95,11 @@ var IAB = {
             browserWrap.style.display = "block";
         }
     },
+    hide: function (win, lose) {
+        if (browserWrap) {
+            browserWrap.style.display = "none";
+        }
+    },
     open: function (win, lose, args) {
         var strUrl = args[0],
             target = args[1],

--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -131,6 +131,21 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
         }
 
+        public void hide(string options)
+        {
+            string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
+
+
+            if (browser != null)
+            {
+                Deployment.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    browser.Visibility = Visibility.Collapsed;
+                    AppBar.IsVisible = false;
+                });
+            }
+        }
+
         public void injectScriptCode(string options)
         {
             string[] args = JSON.JsonHelper.Deserialize<string[]>(options);

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -43,7 +43,10 @@ InAppBrowser.prototype = {
         exec(null, null, "InAppBrowser", "close", []);
     },
     show: function (eventname) {
-      exec(null, null, "InAppBrowser", "show", []);
+        exec(null, null, "InAppBrowser", "show", []);
+    },
+    hide: function (eventname) {
+        exec(null, null, "InAppBrowser", "hide", []);
     },
     addEventListener: function (eventname,f) {
         if (eventname in this.channels) {

--- a/www/windows8/InAppBrowserProxy.js
+++ b/www/windows8/InAppBrowserProxy.js
@@ -43,6 +43,12 @@ var IAB = {
 
         }*/
     },
+    hide: function (win, lose) {
+        /* empty block, ran out of bacon?
+        if (browserWrap) {
+
+        }*/
+    },
     open: function (win, lose, args) {
         var strUrl = args[0],
             target = args[1],


### PR DESCRIPTION
    Added support for hiding the web view container.  This maintains the browser
    session without closing it.  The browser window can be repeatedly hidden and
    shown.
    
    ** This has only been tested on android and ios **
    
    amazon/android:
    An additional `hide` action was added to `InAppBrowser#execute`.  It is
    identical to `show`, except that it calls `dialog.hide()` instead.
    
    blackberry10:
    no changes
    
    firefoxos:
    Added a `hide` method that is identical to `show`, indicating it is not
    supported.
    
    ios:
    Added a `hide` method that is identical to `show`, except that it uses
    `dismissViewControllerAnimated`.  It checks the value of
    `_previousStatusBarStyle`.  If it is `-1`, the method returns with no
    action performed.  If it is not, it is set to `-1.`
    
    ubuntu:
    Added a `hide` method that sets `CordovaWrapper.global.inappbrowser.visible` to
    `false`.
    
    windows:
    Added a `hide` method that sets `browserWrap.style.display` to `none`.
    
    wp:
    Added a `hide` method that is identical to `show`, except that it sets
    `browser.Visibility` to `Visibility.Collapsed` and sets `AppBar.IsVisible` to
    `false`.
