### PR TITLE
Inappbrowser always on top wp8.1

### DIFF
--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -116,6 +116,7 @@ var IAB = {
                 browserWrap.style.height = "calc(100% - 80px)";
                 browserWrap.style.borderStyle = "solid";
                 browserWrap.style.borderColor = "rgba(0,0,0,0.25)";
+                browserWrap.style.zIndex = "999";
 
                 browserWrap.onclick = function () {
                     setTimeout(function () {


### PR DESCRIPTION
For windows 8.1 the inappbrowser can be displayed with a lower zindex
than the current viewing page. Causing the inappbrowser to be opened on
the background.