### PR TITLE
Custom scheme handling 

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -50,6 +50,7 @@ import android.widget.RelativeLayout;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.Config;
+import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
@@ -78,6 +79,11 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String CLOSE_BUTTON_CAPTION = "closebuttoncaption";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
+
+    /*
+    Configuration property. Custom applicaiton scheme to be handeld in a _system.
+     */
+    private static final String CUSTOM_APPLICATION_SCHEME = "CustomAppScheme";
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -109,7 +115,7 @@ public class InAppBrowser extends CordovaPlugin {
             final HashMap<String, Boolean> features = parseFeature(args.optString(2));
             
             Log.d(LOG_TAG, "target = " + target);
-            
+
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
@@ -711,6 +717,9 @@ public class InAppBrowser extends CordovaPlugin {
         public void onPageStarted(WebView view, String url,  Bitmap favicon) {
             super.onPageStarted(view, url, favicon);
             String newloc = "";
+
+            final CordovaPreferences preferences = Config.getPreferences();
+
             if (url.startsWith("http:") || url.startsWith("https:") || url.startsWith("file:")) {
                 newloc = url;
             } 
@@ -763,6 +772,19 @@ public class InAppBrowser extends CordovaPlugin {
                     cordova.getActivity().startActivity(intent);
                 } catch (android.content.ActivityNotFoundException e) {
                     LOG.e(LOG_TAG, "Error sending sms " + url + ":" + e.toString());
+                }
+            }
+            // redirect back to the application
+            else if (url.startsWith(preferences.getString(CUSTOM_APPLICATION_SCHEME, "!@#$"))) {
+                try {
+                  final Intent intent = new Intent(Intent.ACTION_VIEW);
+                  final Uri uri = Uri.parse(url);
+                  intent.setData(uri);
+                  intent.addCategory(Intent.CATEGORY_BROWSABLE);
+                  cordova.getActivity().startActivity(intent);
+                  newloc = "";
+                } catch (final android.content.ActivityNotFoundException e) {
+                  LOG.e(LOG_TAG, "Error during redirection " + url + ":" + e.toString());
                 }
             }
             else {

--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -233,7 +233,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         private async void ShowSystemBrowser(string url)
         {
             var pathUri = new Uri(url, UriKind.Absolute);
-            if (pathUri.Scheme == Uri.UriSchemeHttp || pathUri.Scheme == Uri.UriSchemeHttps)
+            if (pathUri.Scheme == Uri.UriSchemeHttp || pathUri.Scheme == Uri.UriSchemeHttps || pathUri.Scheme == Uri.UriSchemeMailto || pathUri.Scheme == "tel")
             {
                 await Launcher.LaunchUriAsync(pathUri);
                 return;

--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -233,7 +233,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         private async void ShowSystemBrowser(string url)
         {
             var pathUri = new Uri(url, UriKind.Absolute);
-            if (pathUri.Scheme == Uri.UriSchemeHttp || pathUri.Scheme == Uri.UriSchemeHttps || pathUri.Scheme == Uri.UriSchemeMailto || pathUri.Scheme == "tel")
+            if (pathUri.Scheme == Uri.UriSchemeHttp || pathUri.Scheme == Uri.UriSchemeHttps)
             {
                 await Launcher.LaunchUriAsync(pathUri);
                 return;


### PR DESCRIPTION
Currently the inAppBrowser doesn't handle custom application scheme making it impossible to redirect back to the nativeCode from the embedded webView. The system browser handles such redirects without a problem, but due to security reasons in some cases usage of embedded view is more advisable.