### PR TITLE
CB-8635 Improves UX on windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ instance, or the system browser.
     Windows only:
 
     - __hidden__: set to `yes` to create the browser and load the page, but not show it. The loadstop event fires when loading is complete. Omit or set to `no` (default) to have the browser open and load normally.
+    - __fullscreen__: set to `yes` to create the browser control without a border around it. Please note that if __location=no__ is also specified, there will be no control presented to user to close IAB window.
 
 ### Supported Platforms
 
@@ -166,6 +167,10 @@ opened with `target='_blank'`. The rules might look like these
 	color: #777;
 }
 ```
+
+### Windows Quirks
+
+Similar to Firefox OS IAB window visual behaviour can be overridden via `inAppBrowserWrap`/`inAppBrowserWrapFullscreen` CSS classes
 
 ### Browser Quirks
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -197,6 +197,7 @@
         <js-module src="src/windows/InAppBrowserProxy.js" name="InAppBrowserProxy">
             <merges target="" />
         </js-module>
+        <asset src="www/inappbrowser.css" target="css/inappbrowser.css" />
     </platform>
   
     <!-- firefoxos -->

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -34,7 +34,8 @@ var browserWrap,
     navigationButtonsDivInner,
     backButton,
     forwardButton,
-    closeButton;
+    closeButton,
+    bodyOverflowStyle;
 
 // x-ms-webview is available starting from Windows 8.1 (platformId is 'windows')
 // http://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx
@@ -86,6 +87,8 @@ var IAB = {
             if (win) win({ type: "exit" });
 
             browserWrap.parentNode.removeChild(browserWrap);
+            // Reset body overflow style to initial value
+            document.body.style.msOverflowStyle = bodyOverflowStyle;
             browserWrap = null;
             popup = null;
         }
@@ -109,24 +112,25 @@ var IAB = {
         } else {
             // "_blank" or anything else
             if (!browserWrap) {
+                var browserWrapStyle = document.createElement('link');
+                browserWrapStyle.rel = "stylesheet";
+                browserWrapStyle.type = "text/css";
+                browserWrapStyle.href = urlutil.makeAbsolute("/www/css/inappbrowser.css");
+
+                document.head.appendChild(browserWrapStyle);
+
                 browserWrap = document.createElement("div");
-                // First reset all styles for inappbrowser wrapper element
-                browserWrap.style.cssText = "margin:0;padding:0;border:0;outline:0;font-size:100%;vertical-align:baseline;background: 0 0;";
-                browserWrap.style.position = "fixed";
-                browserWrap.style.top = "0px";
-                browserWrap.style.left = "0px";
-                browserWrap.style.width = "100%";
-                browserWrap.style.height = "100%";
-                browserWrap.style.zIndex = 9999;
-                browserWrap.style.border = "40px solid rgba(0,0,0,0.25)";
+                browserWrap.className = "inAppBrowserWrap";
+
+                if (features.indexOf("fullscreen=yes") > -1) {
+                    browserWrap.classList.add("inAppBrowserWrapFullscreen");
+                }
 
                 // Save body overflow style to be able to reset it back later
-                var bodyOverflow = document.body.style.msOverflowStyle;
+                bodyOverflowStyle = document.body.style.msOverflowStyle;
 
                 browserWrap.onclick = function () {
                     setTimeout(function () {
-                        // Reset body overflow style to initial value
-                        document.body.style.msOverflowStyle = bodyOverflow;
                         IAB.close(win);
                     }, 0);
                 };

--- a/www/inappbrowser.css
+++ b/www/inappbrowser.css
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.inAppBrowserWrap {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+    background: 0 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: calc(100% - 80px);
+    height: calc(100% - 80px);
+    z-index: 9999999;
+    border: 40px solid #bfbfbf;
+    border: 40px solid rgba(0, 0, 0, 0.25);
+}
+
+.inAppBrowserWrapFullscreen {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}


### PR DESCRIPTION
This implements some improvements for IAB on window from CB-8635

- Adds `fullscreen` option which allows to open IAB window without gray border around it
- Adds ability to apply custom styles to IAB window via `inAppBrowserWrap` CSS class (similar to Friefox OS)
- Moves styles for IAB container to separate CSS file