### PR TITLE
CB-8467 provide hide method to hide browser window

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
 - removeEventListener
 - close
 - show
+- hide
 - executeScript
 - insertCSS
 
@@ -413,6 +414,27 @@ The function is passed an `InAppBrowserEvent` object.
     var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'hidden=yes');
     // some time later...
     ref.show();
+
+## InAppBrowser.hide
+
+> Hides the InAppBrowser window. Calling this has no effect if the InAppBrowser was already hidden.
+
+    ref.hide();
+
+- __ref__: reference to the InAppBrowser window (`InAppBrowser`)
+
+### Supported Platforms
+
+- Amazon Fire OS
+- Android
+- iOS
+- Windows 8 and 8.1
+
+### Quick Example
+
+    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank');
+    // some time later...
+    ref.hide();
 
 ## InAppBrowser.executeScript
 

--- a/src/amazon/InAppBrowser.java
+++ b/src/amazon/InAppBrowser.java
@@ -212,6 +212,17 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+        else if (action.equals("hide")) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.hide();
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
         else {
             return false;
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -253,6 +253,17 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+        else if (action.equals("hide")) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.hide();
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
         else {
             return false;
         }

--- a/src/firefoxos/InAppBrowserProxy.js
+++ b/src/firefoxos/InAppBrowserProxy.js
@@ -43,6 +43,10 @@ var IABExecs = {
         console.error('[FirefoxOS] show not implemented');
     },
 
+    hide: function (win, lose) {
+        console.error('[FirefoxOS] hide not implemented');
+    },
+
     open: function (win, lose, args) {
         var strUrl = args[0],
             target = args[1],

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -40,6 +40,7 @@
 - (void)close:(CDVInvokedUrlCommand*)command;
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command;
 - (void)show:(CDVInvokedUrlCommand*)command;
+- (void)hide:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -267,30 +267,6 @@
     });
 }
 
-- (void)hide:(CDVInvokedUrlCommand*)command
-{
-    if (self.inAppBrowserViewController == nil) {
-        NSLog(@"Tried to hide IAB after it was closed.");
-        return;
-
-
-    }
-    if (_previousStatusBarStyle == -1) {
-        NSLog(@"Tried to hide IAB while already hidden");
-        return;
-    }
-
-    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
-
-    // Run later to avoid the "took a long time" log message.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.inAppBrowserViewController != nil) {
-            _previousStatusBarStyle = -1;
-            [self.viewController dismissViewControllerAnimated:YES completion:nil];
-        }
-    });
-}
-
 - (void)openInCordovaWebView:(NSURL*)url withOptions:(NSString*)options
 {
     NSURLRequest* request = [NSURLRequest requestWithURL:url];

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -243,6 +243,54 @@
     });
 }
 
+- (void)hide:(CDVInvokedUrlCommand*)command
+{
+    if (self.inAppBrowserViewController == nil) {
+        NSLog(@"Tried to hide IAB after it was closed.");
+        return;
+
+
+    }
+    if (_previousStatusBarStyle == -1) {
+        NSLog(@"Tried to hide IAB while already hidden");
+        return;
+    }
+
+    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
+
+    // Run later to avoid the "took a long time" log message.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.inAppBrowserViewController != nil) {
+            _previousStatusBarStyle = -1;
+            [self.viewController dismissViewControllerAnimated:YES completion:nil];
+        }
+    });
+}
+
+- (void)hide:(CDVInvokedUrlCommand*)command
+{
+    if (self.inAppBrowserViewController == nil) {
+        NSLog(@"Tried to hide IAB after it was closed.");
+        return;
+
+
+    }
+    if (_previousStatusBarStyle == -1) {
+        NSLog(@"Tried to hide IAB while already hidden");
+        return;
+    }
+
+    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
+
+    // Run later to avoid the "took a long time" log message.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.inAppBrowserViewController != nil) {
+            _previousStatusBarStyle = -1;
+            [self.viewController dismissViewControllerAnimated:YES completion:nil];
+        }
+    });
+}
+
 - (void)openInCordovaWebView:(NSURL*)url withOptions:(NSString*)options
 {
     NSURLRequest* request = [NSURLRequest requestWithURL:url];

--- a/src/ubuntu/inappbrowser.cpp
+++ b/src/ubuntu/inappbrowser.cpp
@@ -65,6 +65,10 @@ void Inappbrowser::show(int, int) {
     m_cordova->execQML("CordovaWrapper.global.inappbrowser.visible = true");
 }
 
+void Inappbrowser::hide(int, int) {
+    m_cordova->execQML("CordovaWrapper.global.inappbrowser.visible = false");
+}
+
 void Inappbrowser::close(int, int) {
     m_cordova->execQML("CordovaWrapper.global.inappbrowser.destroy()");
     this->callbackWithoutRemove(_eventCb, EXIT_EVENT);

--- a/src/ubuntu/inappbrowser.h
+++ b/src/ubuntu/inappbrowser.h
@@ -46,6 +46,7 @@ public:
 public slots:
     void open(int cb, int, const QString &url, const QString &windowName, const QString &windowFeatures);
     void show(int, int);
+    void hide(int, int);
     void close(int, int);
     void injectStyleFile(int cb, int, const QString&, bool);
     void injectStyleCode(int cb, int, const QString&, bool);

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -118,6 +118,11 @@ var IAB = {
             }
         });
     },
+    hide: function (win, lose) {
+        if (browserWrap) {
+            browserWrap.style.display = "none";
+        }
+    },
     open: function (win, lose, args) {
         // make function async so that we can add navigation events handlers before view is loaded and navigation occured
         setImmediate(function () {

--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -131,6 +131,21 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
         }
 
+        public void hide(string options)
+        {
+            string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
+
+
+            if (browser != null)
+            {
+                Deployment.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    browser.Visibility = Visibility.Collapsed;
+                    AppBar.IsVisible = false;
+                });
+            }
+        }
+
         public void injectScriptCode(string options)
         {
             string[] args = JSON.JsonHelper.Deserialize<string[]>(options);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -98,6 +98,7 @@ exports.defineAutoTests = function () {
             expect(iabInstance.removeEventListener).toEqual(jasmine.any(Function));
             expect(iabInstance.close).toEqual(jasmine.any(Function));
             expect(iabInstance.show).toEqual(jasmine.any(Function));
+            expect(iabInstance.hide).toEqual(jasmine.any(Function));
             expect(iabInstance.executeScript).toEqual(jasmine.any(Function));
             expect(iabInstance.insertCSS).toEqual(jasmine.any(Function));
         });
@@ -421,7 +422,9 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<p/> <div id="closeHidden"></div>' +
         'Expected result: no output. But click on "show hidden" again and nothing should be shown.' +
         '<p/> <div id="openHiddenShow"></div>' +
-        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk';
+        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk' +
+        '<p/> <div id="openVisibleAndHide"></div>' +
+        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk. Hide after 2 seconds';
 
     var clearing_cache_tests = '<h1>Clearing Cache</h1>' +
         '<div id="openClearCache"></div>' +
@@ -620,6 +623,12 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('google.co.uk Not Hidden', function () {
         openHidden('https://www.google.co.uk', false);
     }, 'openHiddenShow');
+    createActionButton('google.co.uk shown for 2 seconds than hidden', function () {
+        var iab = doOpen('https://www.google.co.uk/', 'random_sting');
+        setTimeout(function () {
+            iab.hide();
+        }, 2000);
+    }, 'openVisibleAndHide');
 
     //Clearing cache
     createActionButton('Clear Browser Cache', function () {

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -50,7 +50,10 @@
             exec(null, null, "InAppBrowser", "close", []);
         },
         show: function (eventname) {
-          exec(null, null, "InAppBrowser", "show", []);
+            exec(null, null, "InAppBrowser", "show", []);
+        },
+        hide: function (eventname) {
+            exec(null, null, "InAppBrowser", "hide", []);
         },
         addEventListener: function (eventname,f) {
             if (eventname in this.channels) {

--- a/www/windows8/InAppBrowserProxy.js
+++ b/www/windows8/InAppBrowserProxy.js
@@ -38,6 +38,12 @@ var IAB = {
 
          }*/
     },
+    hide: function (win, lose) {
+        /* empty block, ran out of bacon?
+        if (browserWrap) {
+
+        }*/
+    },
     open: function (win, lose, args) {
         var strUrl = args[0],
             target = args[1],


### PR DESCRIPTION
Added support for hiding the web view container.  This maintains the browser
session without closing it.  The browser window can be repeatedly hidden and
shown.

** This has only been tested on android and ios **

amazon/android:
An additional `hide` action was added to `InAppBrowser#execute`.  It is
identical to `show`, except that it calls `dialog.hide()` instead.

blackberry10:
no changes

firefoxos:
Added a `hide` method that is identical to `show`, indicating it is not
supported.

ios:
Added a `hide` method that is identical to `show`, except that it uses
`dismissViewControllerAnimated`.  It checks the value of
`_previousStatusBarStyle`.  If it is `-1`, the method returns with no
action performed.  If it is not, it is set to `-1.`

ubuntu:
Added a `hide` method that sets `CordovaWrapper.global.inappbrowser.visible` to
`false`.

windows:
Added a `hide` method that sets `browserWrap.style.display` to `none`.

wp:
Added a `hide` method that is identical to `show`, except that it sets
`browser.Visibility` to `Visibility.Collapsed` and sets `AppBar.IsVisible` to
`false`.