### PR TITLE
Fixed zIndex issue on Windows 8, 8.1 where InAppBrowser opens behind def...

### DIFF
--- a/www/windows8/InAppBrowserProxy.js
+++ b/www/windows8/InAppBrowserProxy.js
@@ -62,6 +62,7 @@ var IAB = {
                 browserWrap.style.borderWidth = "40px";
                 browserWrap.style.borderStyle = "solid";
                 browserWrap.style.borderColor = "rgba(0,0,0,0.25)";
+                browserWrap.style.zIndex = "9999999";
 
                 browserWrap.onclick = function () {
                     setTimeout(function () {

--- a/www/windows8/InAppBrowserProxy.js
+++ b/www/windows8/InAppBrowserProxy.js
@@ -17,11 +17,10 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 /*jslint sloppy:true */
 /*global Windows:true, require, document, setTimeout, window, module */
-
 
 
 var cordova = require('cordova'),
@@ -39,9 +38,9 @@ var IAB = {
     },
     show: function (win, lose) {
         /* empty block, ran out of bacon?
-        if (browserWrap) {
+         if (browserWrap) {
 
-        }*/
+         }*/
     },
     open: function (win, lose, args) {
         var strUrl = args[0],
@@ -72,20 +71,38 @@ var IAB = {
 
                 document.body.appendChild(browserWrap);
             }
+            var localFile = (strUrl.indexOf('ms-appdata:///') > -1);
+            if (localFile) {
+                elem = document.createElement("x-ms-webview");
+                elem.style.width = (window.innerWidth - 80) + "px";
+                elem.style.height = (window.innerHeight - 80) + "px";
+                elem.style.borderWidth = "0px";
+                elem.name = "targetFrame";
+                elem.src = strUrl;
 
-            elem = document.createElement("iframe");
-            elem.style.width = (window.innerWidth - 80) + "px";
-            elem.style.height = (window.innerHeight - 80) + "px";
-            elem.style.borderWidth = "0px";
-            elem.name = "targetFrame";
-            elem.src = strUrl;
+                window.addEventListener("resize", function () {
+                    if (browserWrap && elem) {
+                        elem.style.width = (window.innerWidth - 80) + "px";
+                        elem.style.height = (window.innerHeight - 80) + "px";
+                    }
+                });
 
-            window.addEventListener("resize", function () {
-                if (browserWrap && elem) {
-                    elem.style.width = (window.innerWidth - 80) + "px";
-                    elem.style.height = (window.innerHeight - 80) + "px";
-                }
-            });
+            } else {
+                elem = document.createElement("iframe");
+                elem.style.width = (window.innerWidth - 80) + "px";
+                elem.style.height = (window.innerHeight - 80) + "px";
+                elem.style.borderWidth = "0px";
+                elem.name = "targetFrame";
+                elem.src = strUrl;
+
+
+                window.addEventListener("resize", function () {
+                    if (browserWrap && elem) {
+                        elem.style.width = (window.innerWidth - 80) + "px";
+                        elem.style.height = (window.innerHeight - 80) + "px";
+                    }
+                });
+            }
 
             browserWrap.appendChild(elem);
         } else {


### PR DESCRIPTION
...ault app.

Windows 8 and 8.1 uses the www/windows8/InAppBrowserProxy.js file instead of the default.  The zIndex on the browserWrap was not being set which causes the window to position behind the app calling window.open().  