### PR TITLE
CB-9274 Adds missing methods to InAppBrowser to allow compilation for Amazon FireOS.

### DIFF
--- a/src/amazon/InAppBrowser.java
+++ b/src/amazon/InAppBrowser.java
@@ -84,6 +84,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String LOAD_ERROR_EVENT = "loaderror";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
+    private static final String HARDWARE_BACK_BUTTON = "hardwareback";
 
     private InAppBrowserDialog dialog;
     private AmazonWebView inAppWebView;
@@ -94,6 +95,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean openWindowHidden = false;
     private boolean clearAllCache= false;
     private boolean clearSessionCache=false;
+    private boolean hadwareBackButton=true;
 
     /**
      * Executes the request and returns PluginResult.
@@ -367,7 +369,7 @@ public class InAppBrowser extends CordovaPlugin {
     /**
      * Checks to see if it is possible to go back one page in history, then does so.
      */
-    private void goBack() {
+    public void goBack() {
         this.cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 if (InAppBrowser.this.inAppWebView.canGoBack()) {
@@ -376,6 +378,22 @@ public class InAppBrowser extends CordovaPlugin {
             }
         });
     }
+
+    /**
+     * Can the web browser go back?
+     * @return boolean
+     */
+    public boolean canGoBack() {
+        return this.inAppWebView.canGoBack();
+    }
+
+    /**
+     * Has the user set the hardware back button to go back
+     * @return boolean
+     */
+    public boolean hardwareBack() {
+        return hadwareBackButton;
+    } 
 
     /**
      * Checks to see if it is possible to go forward one page in history, then does so.
@@ -457,6 +475,10 @@ public class InAppBrowser extends CordovaPlugin {
             Boolean hidden = features.get(HIDDEN);
             if (hidden != null) {
                 openWindowHidden = hidden.booleanValue();
+            }
+            Boolean hardwareBack = features.get(HARDWARE_BACK_BUTTON);
+            if (hardwareBack != null) {
+                hadwareBackButton = hardwareBack.booleanValue();
             }
             Boolean cache = features.get(CLEAR_ALL_CACHE);
             if (cache != null) {


### PR DESCRIPTION
Attempting to compile the InAppBrowser plugin for Amazon FireOS fails due to the following programming errors:

```
    [javac] Compiling 8 source files to /path/to/amazon-fireos/ant-build/classes
    [javac] /path/to/amazon-fireos/src/org/apache/cordova/inappbrowser/InAppBrowserDialog.java:51: cannot find symbol
    [javac] symbol  : method hardwareBack()
    [javac] location: class org.apache.cordova.inappbrowser.InAppBrowser
    [javac]             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
    [javac]                                  ^
    [javac] /path/to/amazon-fireos/src/org/apache/cordova/inappbrowser/InAppBrowserDialog.java:51: cannot find symbol
    [javac] symbol  : method canGoBack()
    [javac] location: class org.apache.cordova.inappbrowser.InAppBrowser
    [javac]             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
    [javac]                                                                      ^
    [javac] /path/to/amazon-fireos/src/org/apache/cordova/inappbrowser/InAppBrowserDialog.java:52: goBack() has private access in org.apache.cordova.inappbrowser.InAppBrowser
    [javac]                 this.inAppBrowser.goBack();
    [javac]                                  ^
    [javac] Note: /path/to/amazon-fireos/src/org/apache/cordova/inappbrowser/InAppBrowser.java uses or overrides a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] 3 errors
```

As best I can determine, this problem has existed since plugin version 0.5.2 and was introduced on August 14 in commit 69ca780772b406ab02ec1bd1a8e4dca70052e926. Previous commits had diverged the implementation of InAppBrowser.java in Amazon FireOS such that it was no longer compatible with the InAppBrowser.java for Android.

This fix makes the `goBack()` method public and adds both `canGoBack()` and `hardwareBack()`.

I also recommend updating the project documentation to include the Android options supported by Amazon FireOS, such as hardwareBack. However, I believe that documentation is outside the scope of this issue.
