### PR TITLE
Fix crash on browser window close

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -477,6 +477,11 @@
     return self;
 }
 
+// Prevent crashes on closing windows
+-(void)dealloc {
+   self.webView.delegate = nil;
+}
+
 - (void)createViews
 {
     // We create the views in code for primarily for ease of upgrades and not requiring an external .xib to be included


### PR DESCRIPTION
This fixes references to webView delegates on deallocation to prevent crashes in iOS apps. It is particularly a problem when opening and closing multiple webViews during an Oauth authentication. See
https://issues.apache.org/jira/bro…wse/CB-9167