### PR TITLE
give the ability to trust a certificate authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ simply hook `window.open` during initialization.  For example:
         window.open = cordova.InAppBrowser.open;
     }
 
+If you need to access any sites that use certificates which aren't normally
+trusted, such as self-signed certificates. You can force the InAppBrowser to
+trust them by saving the CA certificate (in DER format) to a file called
+`trusted-ca.der` in your `www` folder. The InAppBrowser will load the file and
+verify that all https URLs use a valid certificate (counting certificates
+issued by the CA you specified). This is an Android only feature.
+
 ## cordova.InAppBrowser.open
 
 Opens a URL in a new `InAppBrowser` instance, the current browser
@@ -383,4 +390,3 @@ Due to [MSDN docs](https://msdn.microsoft.com/en-us/library/windows.ui.xaml.cont
     ref.addEventListener('loadstop', function() {
         ref.insertCSS({file: "mystyles.css"});
     });
-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-plugin-inappbrowser",
+  "name": "cordova-plugin-inappbrowser-orcas",
   "version": "1.3.0",
   "description": "Cordova InAppBrowser Plugin",
   "cordova": {
-    "id": "cordova-plugin-inappbrowser",
+    "id": "cordova-plugin-inappbrowser-orcas",
     "platforms": [
       "android",
       "amazon-fireos",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/apache/cordova-plugin-inappbrowser"
+    "url": "https://github.com/orcasgit/cordova-plugin-inappbrowser"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,8 @@
 -->
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="cordova-plugin-inappbrowser"
-      version="1.0.2-dev">
+           id="com.orcasinc.cordova.inappbrowser"
+      version="1.0.3">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
 -->
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="com.orcasinc.cordova.inappbrowser"
+           id="cordova-plugin-inappbrowser-orcas"
       version="1.3.0">
 
     <name>InAppBrowser</name>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -26,7 +26,9 @@ import android.provider.Browser;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.net.http.SslError;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
@@ -44,6 +46,7 @@ import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.SslErrorHandler;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -60,10 +63,27 @@ import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.StringTokenizer;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class InAppBrowser extends CordovaPlugin {
@@ -115,6 +135,16 @@ public class InAppBrowser extends CordovaPlugin {
             final HashMap<String, Boolean> features = parseFeature(args.optString(2));
 
             Log.d(LOG_TAG, "target = " + target);
+            Log.d(LOG_TAG, "url = " + url);
+
+            if(url.startsWith("https:")) {
+                // Trust any supplied certificate for SSL connections
+                try {
+                    addTrustedCA();
+                } catch (Exception e) {
+                    Log.d(LOG_TAG, "Unable to add trusted CA: " + e.toString());
+                }
+            }
 
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -736,12 +766,56 @@ public class InAppBrowser extends CordovaPlugin {
         }
     }
 
+    private void addTrustedCA() throws IOException, NoSuchAlgorithmException, CertificateException, KeyManagementException, KeyStoreException {
+        Log.d(LOG_TAG, "Adding trusted certificate if it exists");
+        // Load CAs from an InputStream
+        // (could be from a resource or ByteArrayInputStream or ...)
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        InputStream caInput;
+        try {
+            caInput = this.cordova.getActivity().getAssets().open("www/trusted-ca.der");
+        } catch (IOException ex) {
+            Log.d(LOG_TAG, "No trusted certificate authorities supplied: " + ex.toString());
+            return;
+        }
+        Log.d(LOG_TAG, "Found trusted certificate");
+        Certificate ca;
+        try {
+            ca = cf.generateCertificate(caInput);
+            Log.d(LOG_TAG, "ca=" + ((X509Certificate) ca).getSubjectDN());
+        } finally {
+            caInput.close();
+        }
+
+        // Create a KeyStore containing our trusted CAs
+        String keyStoreType = KeyStore.getDefaultType();
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        keyStore.load(null, null);
+        keyStore.setCertificateEntry("ca", ca);
+
+        // Create a TrustManager that trusts the CAs in our KeyStore
+        String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+        tmf.init(keyStore);
+
+        // Create an SSLContext that uses our TrustManager
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, tmf.getTrustManagers(), null);
+
+        // Set up HttpsURLConnection so that default SSL connections use the
+        // socket factory we've made that trusts our certificate authority
+        Log.d(LOG_TAG, "Setting the default SSLSocketFactory");
+        HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+    }
+
     /**
      * The webview client receives notifications about appView
      */
     public class InAppBrowserClient extends WebViewClient {
         EditText edittext;
         CordovaWebView webView;
+        String currentUrl;
+        ArrayList<String> whiteList;
 
         /**
          * Constructor.
@@ -752,6 +826,49 @@ public class InAppBrowser extends CordovaPlugin {
         public InAppBrowserClient(CordovaWebView webView, EditText mEditText) {
             this.webView = webView;
             this.edittext = mEditText;
+            this.currentUrl = null;
+            this.whiteList = new ArrayList<String>();
+        }
+
+        /**
+         * Ignore SSL Certificate errors when the certificate is good with HttpsUrlConnection
+         */
+        @Override
+        public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+            Log.d(LOG_TAG, "We have received an SSL error on this URL: " + error.getUrl());
+            int endIndex = error.getUrl().indexOf("/", 8);
+            endIndex = endIndex == -1 ? (error.getUrl().length() - 1) : endIndex;
+            this.currentUrl = "https://" + error.getUrl().substring(8, endIndex);
+            Log.d(LOG_TAG, "We will verify the certificate on this URL: " + this.currentUrl);
+            if(this.whiteList.contains(this.currentUrl)) {
+                Log.d(LOG_TAG, "Already found the url in the white list, no need to verify it again");
+                handler.proceed();
+            } else {
+                Log.d(LOG_TAG, "The https url was not in the white list, we need to verify it");
+                new CheckSSLTask().execute(handler);
+            }
+        }
+
+        private class CheckSSLTask extends AsyncTask<SslErrorHandler, Void, Void> {
+            protected Void doInBackground(SslErrorHandler... handlers) {
+                try {
+                    HttpsURLConnection con = (HttpsURLConnection) new URL(currentUrl).openConnection();
+                    con.setConnectTimeout(5000);
+                    con.connect();
+                } catch (Exception ex) {
+                    Log.e(LOG_TAG, "Error with the site certificate: " + ex.toString());
+                    handlers[0].cancel();
+                }
+                // We have verified the certificate used by the site is trusted,
+                // white list the url and proceed to load the page
+                whiteList.add(currentUrl);
+                handlers[0].proceed();
+                return null;
+            }
+
+            protected void onPostExecute() {
+                currentUrl = null;
+            }
         }
 
         /**


### PR DESCRIPTION
We found ourselves in a position where we needed to access a site with a certificate issued by a CA not trusted by default in Android. In this case the browser fails silently and remains blank. This is the workaround we came up with:
- You save the CA certificate to `www/trusted-ca.der` when building your cordova app.
- When the plugin loads an https site, the CA gets added to the trusted CAs for `HttpsUrlConnection`
- When an `SSLError` is received, we do the following:
  - Check if the domain of the URL the error is about is in the whitelist (which starts out empty). If so, we ignore the error and proceed.
  - If not, we check if `HttpsUrlConnection` can connect to the domain without a problem. If so, we add it to the whitelist, ignore the error and proceed. If not, we fail.
