### PR TITLE
Added support for file:/// access

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -650,6 +650,10 @@ public class InAppBrowser extends CordovaPlugin {
                 settings.setBuiltInZoomControls(showZoomControls);
                 settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
 
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                    settings.setAllowUniversalAccessFromFileURLs(true);
+                }
+                
                 //Toggle whether this is enabled or not!
                 Bundle appSettings = cordova.getActivity().getIntent().getExtras();
                 boolean enableDatabase = appSettings == null ? true : appSettings.getBoolean("InAppBrowserStorageEnabled", true);


### PR DESCRIPTION
I had the requirement to be able to access file:/// image on my inappbrowser popup in Android. But I had issues with Security.

This was because the WebView wasn't configured to allow universal access from file URLs (required for Jelly Bean or greater).

I think this would be a good idea to include this change in the original plugin, as I'm sure I'm not the only one facing this issue.
