### PR TITLE
Fix lint warnings

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -552,7 +552,7 @@ public class InAppBrowser extends CordovaPlugin {
                 actionButtonContainer.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
                 actionButtonContainer.setHorizontalGravity(Gravity.LEFT);
                 actionButtonContainer.setVerticalGravity(Gravity.CENTER_VERTICAL);
-                actionButtonContainer.setId(1);
+                actionButtonContainer.setId(Integer.valueOf(1));
 
                 // Back button
                 Button back = new Button(cordova.getActivity());
@@ -560,7 +560,7 @@ public class InAppBrowser extends CordovaPlugin {
                 backLayoutParams.addRule(RelativeLayout.ALIGN_LEFT);
                 back.setLayoutParams(backLayoutParams);
                 back.setContentDescription("Back Button");
-                back.setId(2);
+                back.setId(Integer.valueOf(2));
                 Resources activityRes = cordova.getActivity().getResources();
                 int backResId = activityRes.getIdentifier("ic_action_previous_item", "drawable", cordova.getActivity().getPackageName());
                 Drawable backIcon = activityRes.getDrawable(backResId);
@@ -584,7 +584,7 @@ public class InAppBrowser extends CordovaPlugin {
                 forwardLayoutParams.addRule(RelativeLayout.RIGHT_OF, 2);
                 forward.setLayoutParams(forwardLayoutParams);
                 forward.setContentDescription("Forward Button");
-                forward.setId(3);
+                forward.setId(Integer.valueOf(3));
                 int fwdResId = activityRes.getIdentifier("ic_action_next_item", "drawable", cordova.getActivity().getPackageName());
                 Drawable fwdIcon = activityRes.getDrawable(fwdResId);
                 if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN)
@@ -607,7 +607,7 @@ public class InAppBrowser extends CordovaPlugin {
                 textLayoutParams.addRule(RelativeLayout.RIGHT_OF, 1);
                 textLayoutParams.addRule(RelativeLayout.LEFT_OF, 5);
                 edittext.setLayoutParams(textLayoutParams);
-                edittext.setId(4);
+                edittext.setId(Integer.valueOf(4));
                 edittext.setSingleLine(true);
                 edittext.setText(url);
                 edittext.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
@@ -630,7 +630,7 @@ public class InAppBrowser extends CordovaPlugin {
                 closeLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
                 close.setLayoutParams(closeLayoutParams);
                 forward.setContentDescription("Close Button");
-                close.setId(5);
+                close.setId(Integer.valueOf(5));
                 int closeResId = activityRes.getIdentifier("ic_action_remove", "drawable", cordova.getActivity().getPackageName());
                 Drawable closeIcon = activityRes.getDrawable(closeResId);
                 if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN)
@@ -676,7 +676,7 @@ public class InAppBrowser extends CordovaPlugin {
                 }
 
                 inAppWebView.loadUrl(url);
-                inAppWebView.setId(6);
+                inAppWebView.setId(Integer.valueOf(6));
                 inAppWebView.getSettings().setLoadWithOverviewMode(true);
                 inAppWebView.getSettings().setUseWideViewPort(true);
                 inAppWebView.requestFocus();


### PR DESCRIPTION
The latest Android build tools output the following errors when building a project containing the InAppBrowser plugin in release configuration:

```
:lintVitalRelease
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:555: Error: Expected resource of type id [ResourceType]
                actionButtonContainer.setId(1);
                                            ~
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:563: Error: Expected resource of type id [ResourceType]
                back.setId(2);
                           ~
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:587: Error: Expected resource of type id [ResourceType]
                forward.setId(3);
                              ~
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:610: Error: Expected resource of type id [ResourceType]
                edittext.setId(4);
                               ~
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:633: Error: Expected resource of type id [ResourceType]
                close.setId(5);
                            ~
/tmp/builds/pD4TvwB54LApFFdtTl/app/src/org/apache/cordova/inappbrowser/InAppBrowser.java:679: Error: Expected resource of type id [ResourceType]
                inAppWebView.setId(6);
                                   ~

   Explanation for issues of type "ResourceType":
   Ensures that resource id's passed to APIs are of the right type; for
   example, calling Resources.getColor(R.string.name) is wrong.

6 errors, 0 warnings
```