### PR TITLE
Added Android cookie sharing functionality between webviews

### DIFF
--- a/src/amazon/InAppBrowser.java
+++ b/src/amazon/InAppBrowser.java
@@ -164,6 +164,26 @@ public class InAppBrowser extends CordovaPlugin {
                 }
             });
         }
+        else if (action.equals("getCookies")) {
+            String cookieUrl = args.getString(0);
+            String[] cookies = CookieManager.getInstance().getCookie(cookieUrl).split(";");
+            for (String cookie: cookies) {
+                webView.getCookieManager().setCookie(cookieUrl, cookie);
+            }
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, cookies.length);
+            pluginResult.setKeepCallback(true);
+            callbackContext.sendPluginResult(pluginResult);
+        }
+        else if (action.equals("setCookies")) {
+            String cookieUrl = args.getString(0);
+            String[] cookies = webView.getCookieManager().getCookie(args.getString(0)).split(";");
+            for (String cookie: cookies) {
+                CookieManager.getInstance().setCookie(cookieUrl, cookie);
+            }
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, cookies.length);
+            pluginResult.setKeepCallback(true);
+            callbackContext.sendPluginResult(pluginResult);
+        }
         else if (action.equals("close")) {
             closeDialog();
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -192,6 +192,26 @@ public class InAppBrowser extends CordovaPlugin {
                 }
             });
         }
+        else if (action.equals("getCookies")) {
+            String cookieUrl = args.getString(0);
+            String[] cookies = CookieManager.getInstance().getCookie(cookieUrl).split(";");
+            for (String cookie: cookies) {
+                webView.getCookieManager().setCookie(cookieUrl, cookie);
+            }
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, cookies.length);
+            pluginResult.setKeepCallback(true);
+            callbackContext.sendPluginResult(pluginResult);
+        }
+        else if (action.equals("setCookies")) {
+            String cookieUrl = args.getString(0);
+            String[] cookies = webView.getCookieManager().getCookie(args.getString(0)).split(";");
+            for (String cookie: cookies) {
+                CookieManager.getInstance().setCookie(cookieUrl, cookie);
+            }
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, cookies.length);
+            pluginResult.setKeepCallback(true);
+            callbackContext.sendPluginResult(pluginResult);
+        }
         else if (action.equals("close")) {
             closeDialog();
         }

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -80,6 +80,24 @@ InAppBrowser.prototype = {
         } else {
             throw new Error('insertCSS requires exactly one of code or file to be specified');
         }
+    },
+
+    //Gets cookie by Domain from the inAppWebView and adds it to the cordovaWebView.
+    getCookies: function(cookieDetails, cb) {
+        if(cookieDetails.url) {
+            exec(cb, null, "InAppBrowser", "getCookies", [cookieDetails.url, !!cb])
+        } else {
+            throw new Error('getCookie requires a url to be specified')
+        }
+    },
+
+    //Gets cookie by Domain from the cordovaWebView and adds it to the inAppWebView.
+    setCookies: function(cookieDtails, cb) {
+        if(cookieDetails.url) {
+            exec(cb, null, "InAppBrowser", "setCookies", [cookieDetails.url, !!cb])
+        } else {
+            throw new Error('setCookie requires a url to be specified')
+        }
     }
 };
 
@@ -107,4 +125,3 @@ module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
     exec(cb, cb, "InAppBrowser", "open", [strUrl, strWindowName, strWindowFeatures]);
     return iab;
 };
-


### PR DESCRIPTION
There currently exists a gap in functionality with Android as opposed to iOS where iOS will actively share cookies with any inappbrowser webviews, but Android does not. This simply adds in a hook that allows Android to share or get cookies between the Cordova webview and the inappbrowser webview.

Please see the existing discussion below and contribute to it if there are any concerns.