### PR TITLE
CB-9445 Improves executeScript callbacks on iOS

### DIFF
--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -30,7 +30,6 @@
 @class CDVInAppBrowserViewController;
 
 @interface CDVInAppBrowser : CDVPlugin {
-    BOOL _injectedIframeBridge;
 }
 
 @property (nonatomic, retain) CDVInAppBrowserViewController* inAppBrowserViewController;

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -259,11 +259,8 @@
 
 - (void)injectDeferredObject:(NSString*)source withWrapper:(NSString*)jsWrapper
 {
-    if (!_injectedIframeBridge) {
-        _injectedIframeBridge = YES;
-        // Create an iframe bridge in the new document to communicate with the CDVInAppBrowserViewController
-        [self.inAppBrowserViewController.webView stringByEvaluatingJavaScriptFromString:@"(function(d){var e = _cdvIframeBridge = d.createElement('iframe');e.style.display='none';d.body.appendChild(e);})(document)"];
-    }
+    // Ensure an iframe bridge is created to communicate with the CDVInAppBrowserViewController
+    [self.inAppBrowserViewController.webView stringByEvaluatingJavaScriptFromString:@"(function(d){_cdvIframeBridge=d.getElementById('_cdvIframeBridge');if(!_cdvIframeBridge) {var e = _cdvIframeBridge = d.createElement('iframe');e.id='_cdvIframeBridge'; e.style.display='none';d.body.appendChild(e);}})(document)"];
 
     if (jsWrapper != nil) {
         NSData* jsonData = [NSJSONSerialization dataWithJSONObject:@[source] options:0 error:nil];
@@ -400,7 +397,6 @@
 
 - (void)webViewDidStartLoad:(UIWebView*)theWebView
 {
-    _injectedIframeBridge = NO;
 }
 
 - (void)webViewDidFinishLoad:(UIWebView*)theWebView


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-9445

The following code could be used for tests
```
var ref = window.open('http://apache.org', '_blank', 'location=yes');
        ref.addEventListener('loadstart', function() {
            ref.executeScript({code: "window.some_var = 'some value';"},function(){
                 ref.executeScript({code: "window.some_var2 = 'some value2';"},function(){
                    alert('loadstart2 callback');
                  });

                alert('loadstart1 callback');

            });

        });

        ref.addEventListener('loadstop', function() {
            ref.executeScript({code: "alert('loadstop code:' + window.some_var + ' '+ window.some_var2);"},function(){alert('loadstop callback');});
        });
```
