### PR TITLE
Allow for navigateTo method

### DIFF
--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -45,6 +45,9 @@ InAppBrowser.prototype = {
             this.channels[event.type].fire(event);
         }
     },
+    navigateTo: function (newurl) {
+        exec(null, null, "InAppBrowser", "navigate", [newurl]);
+    },
     close: function (eventname) {
         exec(null, null, "InAppBrowser", "close", []);
     },


### PR DESCRIPTION
Adding this method allows for one to navigate to another URL while the inappbrowser is already open.