### PR TITLE
Fix syntax error when browserifying

### DIFF
--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -22,7 +22,6 @@
 // special patch to correctly work on Ripple emulator (CB-9760)
 if (window.parent && !!window.parent.ripple) { // https://gist.github.com/triceam/4658021
     module.exports = window.open.bind(window); // fallback to default window.open behaviour
-    return;
 }
 
 var exec = require('cordova/exec');


### PR DESCRIPTION
When browserifying this plugin, aliasify throws an error:
```
events.js:141
      throw er; // Unhandled 'error' event
      ^

SyntaxError: 'return' outside of function (25:4) (while aliasify was processing plugins/cordova-plugin-inappbrowser/www/inappbrowser.js) while parsing file: plugins/cordova-plugin-inappbrowser/www/inappbrowser.js
```