### PR TITLE
Make WP respect location=no

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -126,7 +126,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {
                     browser.Visibility = Visibility.Visible;
-                    AppBar.IsVisible = true;
+                    AppBar.IsVisible = ShowLocation;
                 });
             }
         }
@@ -345,7 +345,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                             bar.Buttons.Add(closeBtn);
 
                             page.ApplicationBar = bar;
-                            bar.IsVisible = !StartHidden;
+                            bar.IsVisible = ShowLocation && !StartHidden;
                             AppBar = bar;
 
                             page.BackKeyPress += page_BackKeyPress;


### PR DESCRIPTION
The WP version reads the location parameter but seemingly never uses it. This would make it hide the "AppBar" with the back/next/exit buttons which seem to be the closest thing to a location bar it has.
