### PR TITLE
Fix for CB-10305

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -748,6 +748,10 @@
     return UIStatusBarStyleDefault;
 }
 
+- (BOOL)prefersStatusBarHidden {
+    return NO;
+}
+
 - (void)close
 {
     [CDVUserAgentUtil releaseLock:&_userAgentLockToken];
@@ -993,13 +997,26 @@
 
     // simplified from: http://stackoverflow.com/a/25669695/219684
 
-    UIToolbar* bgToolbar = [[UIToolbar alloc] initWithFrame:frame];
+    UIToolbar* bgToolbar = [[UIToolbar alloc] initWithFrame:[self invertFrameIfNeeded:frame]];
     bgToolbar.barStyle = UIBarStyleDefault;
+    [bgToolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
     [self.view addSubview:bgToolbar];
 
     [super viewDidLoad];
 }
 
+- (CGRect) invertFrameIfNeeded:(CGRect)rect {
+    // We need to invert since on iOS 7 frames are always in Portrait context
+    if (!IsAtLeastiOSVersion(@"8.0")) {
+        if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+            CGFloat temp = rect.size.width;
+            rect.size.width = rect.size.height;
+            rect.size.height = temp;
+            rect.origin = CGPointZero;
+        }
+    }
+    return rect;
+}
 
 #pragma mark CDVScreenOrientationDelegate
 


### PR DESCRIPTION
There are really 3 issues here.
1. When the inAppBrowser is started in portrait and rotates, the
background of the status bar doesn’t fill the whole area. (any iOS
version)
2. On iOS 7, if the inAppBrowser plugin is started on landscape, the
background of the status bar was vertical.
3. On iOS 8-9, on iPhone/iPod, the status bar disappears on landscape,
but the background doesn’t disappear. I’ve changed it to make the
status bar appear  on landscape too. (This wasn’t on CB-10305, but I
think it’s related)