### PR TITLE
Add fix for iOS file upload.

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -987,6 +987,12 @@
 
 @implementation CDVInAppBrowserNavigationController : UINavigationController
 
+- (void) dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
+    if ( self.presentedViewController) {
+        [super dismissViewControllerAnimated:flag completion:completion];
+    }
+}
+
 - (void) viewDidLoad {
 
     CGRect frame = [UIApplication sharedApplication].statusBarFrame;


### PR DESCRIPTION
I'd like to start by saying I don't understand fully what the issue is or how this fixes the issue. I have been having an issue where my cordova app would fall back to the splash screen when I tried to upload a file on iOS. I found the solution here https://issues.apache.org/jira/browse/CB-7679 

This is before the fix
![file_upload_bug](https://cloud.githubusercontent.com/assets/1206124/12428174/04e7daa0-be98-11e5-85bb-2f58bebcad7e.gif)

and this is after
![file_upload_bug_fixed](https://cloud.githubusercontent.com/assets/1206124/12428184/0f049848-be98-11e5-81d6-ac2286210036.gif)

I am not sure why this fix wasn't already included so I am hoping it just because no one has taken the time to make a PR. Any issues with this?