### PR TITLE
CB-10538 cordova-plugin-inappbrowser timeout issue

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -42,13 +42,13 @@ exports.defineAutoTests = function () {
 
         var iabInstance;
         var originalTimeout;
-        var url = 'http://apache.org/';
+        var url = 'https://dist.apache.org/repos/dist/dev/cordova/';
         var badUrl = 'http://bad-uri/';
 
         beforeEach(function () {
             // increase timeout to ensure test url could be loaded within test time
             originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-            jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
             iabInstance = null;
         });


### PR DESCRIPTION
Switched to Apache dist as test page and increased timeout just in case (looks like there are some scripts on Apache page preventing page to be fully loaded in time in some cases).

@alsorokin PTAL as you have stable repro.