### PR TITLE
Fixes CB-10607

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -1019,8 +1019,8 @@
             CGFloat temp = rect.size.width;
             rect.size.width = rect.size.height;
             rect.size.height = temp;
-            rect.origin = CGPointZero;
         }
+        rect.origin = CGPointZero;
     }
     return rect;
 }


### PR DESCRIPTION
When the device is in portrait upside down the toolbar appears at the
bottom. This fix set the origin to the 0,0 point