### PR TITLE
send back loaderror when "show" fails.

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -191,9 +191,9 @@ public class InAppBrowser extends CordovaPlugin {
                         result = showWebPage(url, features);
                     }
 
-                    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
-                    pluginResult.setKeepCallback(true);
-                    callbackContext.sendPluginResult(pluginResult);
+                    if (!result.equals("")) {
+                        sendErrorEvent(url, 0, result, false);
+                    }
                 }
             });
         }
@@ -743,6 +743,19 @@ public class InAppBrowser extends CordovaPlugin {
         return "";
     }
 
+    private void sendErrorEvent(String url, int code, String message, boolean keepCallback) {
+        try {
+            JSONObject obj = new JSONObject();
+            obj.put("type", LOAD_ERROR_EVENT);
+            obj.put("url", url);
+            obj.put("code", code);
+            obj.put("message", message);
+            sendUpdate(obj, keepCallback, PluginResult.Status.ERROR);
+        } catch (JSONException ex) {
+            Log.d(LOG_TAG, "Should never happen");
+        }
+    }
+
     /**
      * Create a new plugin success result and send it back to JavaScript
      *
@@ -914,17 +927,7 @@ public class InAppBrowser extends CordovaPlugin {
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
             super.onReceivedError(view, errorCode, description, failingUrl);
 
-            try {
-                JSONObject obj = new JSONObject();
-                obj.put("type", LOAD_ERROR_EVENT);
-                obj.put("url", failingUrl);
-                obj.put("code", errorCode);
-                obj.put("message", description);
-
-                sendUpdate(obj, true, PluginResult.Status.ERROR);
-            } catch (JSONException ex) {
-                Log.d(LOG_TAG, "Should never happen");
-            }
+            sendErrorEvent(failingUrl, errorCode, description, true);
         }
 
         /**


### PR DESCRIPTION
I noticed that when I try to open "_system", it silently fails, but returns the error message as a result. In the js code, that error doesn't end up calling any event listeners on the iab object.
I removed the useless "sendPluginResult" when the result is an empty string, and called the "loaderror" event on failure (when the result is not empty)
