### PR TITLE
doc: do not use `with` in JS samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,14 +235,11 @@ function showHelp(url) {
 
     inAppBrowserRef = cordova.InAppBrowser.open(url, target, options);
 
-    with (inAppBrowserRef) {
+    inAppBrowserRef.addEventListener('loadstart', loadStartCallBack);
 
-        addEventListener('loadstart', loadStartCallBack);
+    inAppBrowserRef.addEventListener('loadstop', loadStopCallBack);
 
-        addEventListener('loadstop', loadStopCallBack);
-
-        addEventListener('loaderror', loadErrorCallBack);
-    }
+    inAppBrowserRef.addEventListener('loaderror', loadErrorCallBack);
 
 }
 
@@ -544,14 +541,11 @@ function showHelp(url) {
 
     inAppBrowserRef = cordova.InAppBrowser.open(url, target, options);
 
-    with (inAppBrowserRef) {
+    inAppBrowserRef.addEventListener('loadstart', loadStartCallBack);
 
-        addEventListener('loadstart', loadStartCallBack);
+    inAppBrowserRef.addEventListener('loadstop', loadStopCallBack);
 
-        addEventListener('loadstop', loadStopCallBack);
-
-        addEventListener('loaderror', loadErrorCallBack);
-    }
+    inAppBrowserRef.addEventListener('loaderror', loadErrorCallBack);
 
 }
 


### PR DESCRIPTION
The usage of `with` JS statement is highly discouraged for a number of reasons, see

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with
http://www.2ality.com/2011/06/with-statement.html