### PR TITLE
Window size and position in browser platform

### DIFF
--- a/src/browser/InAppBrowserProxy.js
+++ b/src/browser/InAppBrowserProxy.js
@@ -77,9 +77,12 @@ var IAB = {
             if (!browserWrap) {
                 browserWrap = document.createElement("div");
                 browserWrap.style.position = "absolute";
+                browserWrap.style.top = "0";
+                browserWrap.style.left = "0";
+                browserWrap.style.boxSizing = "border-box";
                 browserWrap.style.borderWidth = "40px";
-                browserWrap.style.width = "calc(100% - 80px)";
-                browserWrap.style.height = "calc(100% - 80px)";
+                browserWrap.style.width = "100vw";
+                browserWrap.style.height = "100vh";
                 browserWrap.style.borderStyle = "solid";
                 browserWrap.style.borderColor = "rgba(0,0,0,0.25)";
 


### PR DESCRIPTION
CSS updated for iframe wrapper in browser platform. Styles and position of wrapper were dependent on parent element, global styles and other elements in body.
Now the wrapper/iframe should always cover entire window.