### PR TITLE
CB-10973 inAppBrowser for Windows Platform: wrong height of webview w…

### DIFF
--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -176,6 +176,7 @@ var IAB = {
                 }
                 popup.style.borderWidth = "0px";
                 popup.style.width = "100%";
+                popup.style.marginBottom = "-3px";
 
                 browserWrap.appendChild(popup);
 


### PR DESCRIPTION
…ith location=yes

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Removes a transparent gap between x-ms-webview and bottom appbar.

### What testing has been done on this change?
Windows 8.1/10, Windows Phone 8.1/10, normal and fullscreen modes, portrait and landscape orientations.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

[Jira issue](https://issues.apache.org/jira/browse/CB-10973)