### PR TITLE
CB-11136: InAppBrowser fails to close with WKWebView OAuth

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -238,7 +238,14 @@
     // Run later to avoid the "took a long time" log message.
     dispatch_async(dispatch_get_main_queue(), ^{
         if (weakSelf.inAppBrowserViewController != nil) {
-            [weakSelf.viewController presentViewController:nav animated:YES completion:nil];
+            CGRect frame = [[UIScreen mainScreen] bounds];
+            UIWindow *tmpWindow = [[UIWindow alloc] initWithFrame:frame];
+            UIViewController *tmpController = [[UIViewController alloc] init];
+            [tmpWindow setRootViewController:tmpController];
+            [tmpWindow setWindowLevel:UIWindowLevelAlert];
+
+            [tmpWindow makeKeyAndVisible];
+            [tmpController presentViewController:nav animated:YES completion:nil];
         }
     });
 }
@@ -401,7 +408,7 @@
             [self.commandDelegate sendPluginResult:pluginResult callbackId:scriptCallbackId];
             return NO;
         }
-    } 
+    }
     //if is an app store link, let the system handle it, otherwise it fails to load it
     else if ([[ url scheme] isEqualToString:@"itms-appss"] || [[ url scheme] isEqualToString:@"itms-apps"]) {
         [theWebView stopLoading];
@@ -492,7 +499,7 @@
 #else
         _webViewDelegate = [[CDVWebViewDelegate alloc] initWithDelegate:self];
 #endif
-        
+
         [self createViews];
     }
 


### PR DESCRIPTION
This is NOT a duplicate of https://github.com/apache/cordova-plugin-inappbrowser/pull/162 even so they try to fix the same issue.

This PR takes a completely different approach that does not hack around custom UIView animations and uses an accepted strategy known by iOS developers, using an auxiliar UIWindow (built-in UIAlertView used to do that).
### Platforms affected

iOS (device only)
### What does this PR do?

Avoids presenting the InAppBrowser directly over the UIViewController used by WKWebView which causes the WKWebView thread to block.

Since the WKWebView thread is blocked it can not receive some important events like 'loadend', preventing the use of OAuth.
### What testing has been done on this change?

Testing in Simulator iOS9.3, Simulator iOS10, Device iOS10
### Ionic WKWebView issues

https://github.com/driftyco/cordova-plugin-wkwebview-engine/issues/51
https://github.com/driftyco/cordova-plugin-wkwebview-engine/issues/37
### Checklist
- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
