### PR TITLE
CB-11694 Android: Set hadwareBackButton value according option in cordova.InAppBrowser.open

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -87,6 +87,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HARDWARE_BACK_BUTTON = "hardwareback";
     private static final String MEDIA_PLAYBACK_REQUIRES_USER_ACTION = "mediaPlaybackRequiresUserAction";
     private static final String SHOULD_PAUSE = "shouldPauseOnSuspend";
+    private static final Boolean DEFAULT_HARDWARE_BACK = true;
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -521,7 +522,9 @@ public class InAppBrowser extends CordovaPlugin {
             Boolean hardwareBack = features.get(HARDWARE_BACK_BUTTON);
             if (hardwareBack != null) {
                 hadwareBackButton = hardwareBack.booleanValue();
-            }
+            } else {
+                hadwareBackButton = DEFAULT_HARDWARE_BACK;
+            }            
             Boolean mediaPlayback = features.get(MEDIA_PLAYBACK_REQUIRES_USER_ACTION);
             if (mediaPlayback != null) {
                 mediaPlaybackRequiresUserGesture = mediaPlayback.booleanValue();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -444,7 +444,9 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<p/> <div id="openHardwareBackYes"></div>' +
         'Expected result: hardwareback=yes pressing back button should navigate backwards in history then close InAppBrowser' +
         '<p/> <div id="openHardwareBackNo"></div>' +
-        'Expected result: hardwareback=no pressing back button should close InAppBrowser regardless history';
+        'Expected result: hardwareback=no pressing back button should close InAppBrowser regardless history' + 
+        '<p/> <div id="openHardwareBackDefaultAfterNo"></div>' +
+        'Expected result: consistently open browsers with with the appropriate option: hardwareback=defaults to yes then hardwareback=no then hardwareback=defaults to yes. By default hardwareback is yes so pressing back button should navigate backwards in history then close InAppBrowser';
 
     // CB-7490 We need to wrap this code due to Windows security restrictions
     // see http://msdn.microsoft.com/en-us/library/windows/apps/hh465380.aspx#differences for details
@@ -651,4 +653,19 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('hardwareback=no', function () {
         doOpen('http://cordova.apache.org', '_blank', 'hardwareback=no');
     }, 'openHardwareBackNo');
+    createActionButton('no hardwareback -> hardwareback=no -> no hardwareback', function() {
+        var ref = cordova.InAppBrowser.open('https://google.com', '_blank', 'location=yes');
+        ref.addEventListener('loadstop', function() {
+            ref.close();
+        });
+        ref.addEventListener('exit', function() {
+            var ref2 = cordova.InAppBrowser.open('https://google.com', '_blank', 'location=yes,hardwareback=no');
+            ref2.addEventListener('loadstop', function() {
+                ref2.close();
+            });
+            ref2.addEventListener('exit', function() {
+                cordova.InAppBrowser.open('https://google.com', '_blank', 'location=yes');
+            });
+        });
+    }, 'openHardwareBackDefaultAfterNo');
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
HadwareBackButton value persists across usages. By default hardwareBack value is null. In this case we should set hadwareBackButton  to default value.

### What testing has been done on this change?
Manual test

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

