### PR TITLE
CB-12020 Android and iOS: add a method to hide an InAppBrowser after it was shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
 - removeEventListener
 - close
 - show
+- hide (Android and iOS only)
 - executeScript
 - insertCSS
 
@@ -394,7 +395,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ## InAppBrowser.show
 
-> Displays an InAppBrowser window that was opened hidden. Calling this has no effect if the InAppBrowser was already visible.
+> Displays an InAppBrowser window that was opened hidden or was hidden manually by calling the `InAppBrowser.hide` method. Calling this has no effect if the InAppBrowser was already visible.
 
     ref.show();
 
@@ -413,6 +414,30 @@ The function is passed an `InAppBrowserEvent` object.
     var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'hidden=yes');
     // some time later...
     ref.show();
+
+## InAppBrowser.hide
+
+> Hides an InAppBrowser window. Calling this has no effect if the InAppBrowser was already hidden.
+
+    ref.hide();
+
+- __ref__: reference to the InAppBrowser window (`InAppBrowser`)
+
+### Supported Platforms
+
+- Android
+- iOS
+
+### Quick Example
+
+    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'hidden=yes');
+    // some time later...
+    ref.show();
+    // some time later...
+    ref.hide();
+    // some time later...
+    ref.show();
+    // and so on...
 
 ## InAppBrowser.executeScript
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -253,6 +253,17 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+        else if (action.equals("hide")) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.hide();
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
         else {
             return false;
         }

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -40,6 +40,7 @@
 - (void)close:(CDVInvokedUrlCommand*)command;
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command;
 - (void)show:(CDVInvokedUrlCommand*)command;
+- (void)hide:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -243,6 +243,23 @@
     });
 }
 
+- (void)hide:(CDVInvokedUrlCommand*)command
+{
+    if (self.inAppBrowserViewController == nil) {
+        NSLog(@"Tried to hide IAB after it was closed.");
+        return;
+    }
+    if (_previousStatusBarStyle == -1) {
+        NSLog(@"Tried to hide IAB while already hidden");
+        return;
+    }
+
+    if (self.inAppBrowserViewController != nil) {
+        [[self.inAppBrowserViewController presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+        _previousStatusBarStyle = -1;
+    }
+}
+
 - (void)openInCordovaWebView:(NSURL*)url withOptions:(NSString*)options
 {
     NSURLRequest* request = [NSURLRequest requestWithURL:url];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -98,6 +98,7 @@ exports.defineAutoTests = function () {
             expect(iabInstance.removeEventListener).toEqual(jasmine.any(Function));
             expect(iabInstance.close).toEqual(jasmine.any(Function));
             expect(iabInstance.show).toEqual(jasmine.any(Function));
+            expect(iabInstance.hide).toEqual(jasmine.any(Function));
             expect(iabInstance.executeScript).toEqual(jasmine.any(Function));
             expect(iabInstance.insertCSS).toEqual(jasmine.any(Function));
         });
@@ -421,7 +422,9 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<p/> <div id="closeHidden"></div>' +
         'Expected result: no output. But click on "show hidden" again and nothing should be shown.' +
         '<p/> <div id="openHiddenShow"></div>' +
-        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk';
+        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk' +
+        '<p/> <div id="openVisibleAndHide"></div>' +
+        'Expected result: open successfully in InAppBrowser to https://www.google.co.uk. Hide after 2 seconds';
 
     var clearing_cache_tests = '<h1>Clearing Cache</h1>' +
         '<div id="openClearCache"></div>' +
@@ -449,7 +452,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '<p/> <div id="openHardwareBackYes"></div>' +
         'Expected result: hardwareback=yes pressing back button should navigate backwards in history then close InAppBrowser' +
         '<p/> <div id="openHardwareBackNo"></div>' +
-        'Expected result: hardwareback=no pressing back button should close InAppBrowser regardless history' + 
+        'Expected result: hardwareback=no pressing back button should close InAppBrowser regardless history' +
         '<p/> <div id="openHardwareBackDefaultAfterNo"></div>' +
         'Expected result: consistently open browsers with with the appropriate option: hardwareback=defaults to yes then hardwareback=no then hardwareback=defaults to yes. By default hardwareback is yes so pressing back button should navigate backwards in history then close InAppBrowser';
 
@@ -620,6 +623,12 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('google.co.uk Not Hidden', function () {
         openHidden('https://www.google.co.uk', false);
     }, 'openHiddenShow');
+    createActionButton('google.co.uk shown for 2 seconds than hidden', function () {
+        var iab = doOpen(url, 'random_sting');
+        setTimeout(function () {
+            iab.hide();
+        }, 2000);
+    }, 'openVisibleAndHide');
 
     //Clearing cache
     createActionButton('Clear Browser Cache', function () {

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -52,6 +52,9 @@
         show: function (eventname) {
           exec(null, null, "InAppBrowser", "show", []);
         },
+        hide: function (eventname) {
+          exec(null, null, "InAppBrowser", "hide", []);
+        },
         addEventListener: function (eventname,f) {
             if (eventname in this.channels) {
                 this.channels[eventname].subscribe(f);


### PR DESCRIPTION
### Platforms affected
Android, iOS

### What does this PR do?
add a hide() method to hide the InAppBrowser. You can make it reappear my calling the show() method (again).

### What testing has been done on this change?
- automated test: check for the existence of the hide() method
- manual test: open InAppBrowser visible, than hide it (after 2 seconds)

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
