### PR TITLE
CB-10973 inAppBrowser for Windows Platform: wrong height of webview w…

### DIFF
--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -181,7 +181,7 @@ var IAB = {
                 }
                 popup.style.borderWidth = "0px";
                 popup.style.width = "100%";
-                popup.style.marginBottom = "-3px";
+                popup.style.marginBottom = "-5px";
 
                 browserWrap.appendChild(popup);
 


### PR DESCRIPTION
…ith location=yes

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Redoing as there was still a little gap

### What testing has been done on this change?
Tested on Windows Phone 8.1 Lumia 640, 525,
Windows 10 Mobile 525, 1520,
Windows 10 desktop

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
