### PR TITLE
CB-9148 - (android) Add support for input[type=file] to InAppBrowser!

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -894,7 +894,7 @@ public class InAppBrowser extends CordovaPlugin {
 
     /**
      * Receive File Data from File Chooser
-     *
+     * 
      * @param requestCode the requested code from chromeclient
      * @param resultCode the result code returned from android system
      * @param intent the data from android file chooser

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1048,7 +1048,6 @@ public class InAppBrowser extends CordovaPlugin {
         }
 
 
-
         public void onPageFinished(WebView view, String url) {
             super.onPageFinished(view, url);
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -409,7 +409,7 @@ public class InAppBrowser extends CordovaPlugin {
             intent.putExtra(Browser.EXTRA_APPLICATION_ID, cordova.getActivity().getPackageName());
             this.cordova.getActivity().startActivity(intent);
             return "";
-        // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
+            // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
         } catch (java.lang.RuntimeException e) {
             LOG.d(LOG_TAG, "InAppBrowser: Error loading url "+url+":"+ e.toString());
             return e.toString();
@@ -571,7 +571,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             Boolean wideViewPort = features.get(USER_WIDE_VIEW_PORT);
             if (wideViewPort != null ) {
-		            useWideViewPort = wideViewPort.booleanValue();
+                useWideViewPort = wideViewPort.booleanValue();
             }
         }
 
@@ -586,8 +586,8 @@ public class InAppBrowser extends CordovaPlugin {
              */
             private int dpToPixels(int dipValue) {
                 int value = (int) TypedValue.applyDimension( TypedValue.COMPLEX_UNIT_DIP,
-                                                            (float) dipValue,
-                                                            cordova.getActivity().getResources().getDisplayMetrics()
+                        (float) dipValue,
+                        cordova.getActivity().getResources().getDisplayMetrics()
                 );
 
                 return value;
@@ -695,8 +695,8 @@ public class InAppBrowser extends CordovaPlugin {
                     public boolean onKey(View v, int keyCode, KeyEvent event) {
                         // If the event is a key-down event on the "enter" button
                         if ((event.getAction() == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                          navigate(edittext.getText().toString());
-                          return true;
+                            navigate(edittext.getText().toString());
+                            return true;
                         }
                         return false;
                     }
@@ -893,6 +893,42 @@ public class InAppBrowser extends CordovaPlugin {
     }
 
     /**
+     * Receive File Data from File Chooser
+     *
+     * @param requestCode the requested code from chromeclient
+     * @param resultCode the result code returned from android system
+     * @param intent the data from android file chooser
+     */
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        // For Android >= 5.0
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Log.i("mytag", "onActivityResult (For Android >= 5.0)");
+            // If RequestCode or Callback is Invalid
+            if(requestCode != FILECHOOSER_REQUESTCODE_LOLLIPOP || mUploadCallbackLollipop == null) {
+                super.onActivityResult(requestCode, resultCode, intent);
+                return;
+            }
+            mUploadCallbackLollipop.onReceiveValue(WebChromeClient.FileChooserParams.parseResult(resultCode, intent));
+            mUploadCallbackLollipop = null;
+        }
+        // For Android < 5.0
+        else {
+            Log.i("mytag", "onActivityResult (For Android < 5.0)");
+            // If RequestCode or Callback is Invalid
+            if(requestCode != FILECHOOSER_REQUESTCODE || mUploadCallback == null) {
+                super.onActivityResult(requestCode, resultCode, intent);
+                return;
+            }
+
+            if (null == mUploadCallback) return;
+            Uri result = intent == null || resultCode != cordova.getActivity().RESULT_OK ? null : intent.getData();
+
+            mUploadCallback.onReceiveValue(result);
+            mUploadCallback = null;
+        }
+    }
+
+    /**
      * The webview client receives notifications about appView
      */
     public class InAppBrowserClient extends WebViewClient {
@@ -999,7 +1035,7 @@ public class InAppBrowser extends CordovaPlugin {
             // Update the UI if we haven't already
             if (!newloc.equals(edittext.getText().toString())) {
                 edittext.setText(newloc);
-             }
+            }
 
             try {
                 JSONObject obj = new JSONObject();
@@ -1086,36 +1122,6 @@ public class InAppBrowser extends CordovaPlugin {
 
             // By default handle 401 like we'd normally do!
             super.onReceivedHttpAuthRequest(view, handler, host, realm);
-        }
-
-        @Override
-        public void onActivityResult(int requestCode, int resultCode, Intent intent) {
-            // For Android >= 5.0
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                Log.i("mytag", "onActivityResult (For Android >= 5.0)");
-                // If RequestCode or Callback is Invalid
-                if(requestCode != FILECHOOSER_REQUESTCODE_LOLLIPOP || mUploadCallbackLollipop == null) {
-                    super.onActivityResult(requestCode, resultCode, intent);
-                    return;
-                }
-                mUploadCallbackLollipop.onReceiveValue(WebChromeClient.FileChooserParams.parseResult(resultCode, intent));
-                mUploadCallbackLollipop = null;
-            }
-            // For Android < 5.0
-            else {
-                Log.i("mytag", "onActivityResult (For Android < 5.0)");
-                // If RequestCode or Callback is Invalid
-                if(requestCode != FILECHOOSER_REQUESTCODE || mUploadCallback == null) {
-                    super.onActivityResult(requestCode, resultCode, intent);
-                    return;
-                }
-
-                if (null == mUploadCallback) return;
-                Uri result = intent == null || resultCode != cordova.getActivity().RESULT_OK ? null : intent.getData();
-
-                mUploadCallback.onReceiveValue(result);
-                mUploadCallback = null;
-            }
         }
     }
 }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -29,7 +29,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -734,7 +733,7 @@ public class InAppBrowser extends CordovaPlugin {
                     // For Android 5.0+
                     public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
                     {
-                        Log.d(LOG_TAG, "File Chooser 5.0+");
+                        LOG.d(LOG_TAG, "File Chooser 5.0+");
                         // If callback exists, finish it.
                         if(mUploadCallbackLollipop != null) {
                             mUploadCallbackLollipop.onReceiveValue(null);
@@ -746,16 +745,15 @@ public class InAppBrowser extends CordovaPlugin {
                         content.addCategory(Intent.CATEGORY_OPENABLE);
                         content.setType("*/*");
 
-                        // [important] Register ActvityResultCallback on Cordova
-                        cordova.setActivityResultCallback(InAppBrowser.this);
-                        cordova.getActivity().startActivityForResult(content, FILECHOOSER_REQUESTCODE_LOLLIPOP);
+                        // Run cordova startActivityForResult
+                        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE_LOLLIPOP);
                         return true;
                     }
 
                     // For Android 4.1+
                     public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType, String capture)
                     {
-                        Log.d(LOG_TAG, "File Chooser 4.1+");
+                        LOG.d(LOG_TAG, "File Chooser 4.1+");
                         // Call file chooser for Android 3.0+
                         openFileChooser(uploadMsg, acceptType);
                     }
@@ -763,20 +761,13 @@ public class InAppBrowser extends CordovaPlugin {
                     // For Android 3.0+
                     public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType)
                     {
-                        Log.d(LOG_TAG, "File Chooser 3.0+");
+                        LOG.d(LOG_TAG, "File Chooser 3.0+");
                         mUploadCallback = uploadMsg;
-                        Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-                        i.addCategory(Intent.CATEGORY_OPENABLE);
+                        Intent content = new Intent(Intent.ACTION_GET_CONTENT);
+                        content.addCategory(Intent.CATEGORY_OPENABLE);
 
-                        cordova.setActivityResultCallback(InAppBrowser.this);
-                        cordova.getActivity().startActivityForResult( Intent.createChooser(i, "File Chooser"), FILECHOOSER_REQUESTCODE);
-                    }
-
-                    // For Android < 3.0
-                    public void openFileChooser(ValueCallback<Uri> uploadMsg) {
-                        Log.d(LOG_TAG, "File Chooser 3.0 <");
-                        // Call file chooser for Android 3.0+
-                        openFileChooser(uploadMsg, "");
+                        // run startActivityForResult
+                        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE);
                     }
 
                 });
@@ -898,7 +889,7 @@ public class InAppBrowser extends CordovaPlugin {
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         // For Android >= 5.0
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            Log.i("mytag", "onActivityResult (For Android >= 5.0)");
+            LOG.d(LOG_TAG, "onActivityResult (For Android >= 5.0)");
             // If RequestCode or Callback is Invalid
             if(requestCode != FILECHOOSER_REQUESTCODE_LOLLIPOP || mUploadCallbackLollipop == null) {
                 super.onActivityResult(requestCode, resultCode, intent);
@@ -909,7 +900,7 @@ public class InAppBrowser extends CordovaPlugin {
         }
         // For Android < 5.0
         else {
-            Log.i("mytag", "onActivityResult (For Android < 5.0)");
+            LOG.d(LOG_TAG, "onActivityResult (For Android < 5.0)");
             // If RequestCode or Callback is Invalid
             if(requestCode != FILECHOOSER_REQUESTCODE || mUploadCallback == null) {
                 super.onActivityResult(requestCode, resultCode, intent);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -41,6 +42,8 @@ import android.view.inputmethod.InputMethodManager;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import android.webkit.HttpAuthHandler;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -67,10 +70,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.StringTokenizer;
-
-import android.util.Log;
-import android.webkit.ValueCallback;
-import android.webkit.WebChromeClient;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class InAppBrowser extends CordovaPlugin {
@@ -107,7 +106,6 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
     private boolean useWideViewPort = true;
-
     private ValueCallback<Uri> mUploadCallback;
     private ValueCallback<Uri[]> mUploadCallbackLollipop;
     private final static int FILECHOOSER_REQUESTCODE = 1;
@@ -409,7 +407,7 @@ public class InAppBrowser extends CordovaPlugin {
             intent.putExtra(Browser.EXTRA_APPLICATION_ID, cordova.getActivity().getPackageName());
             this.cordova.getActivity().startActivity(intent);
             return "";
-            // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
+        // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
         } catch (java.lang.RuntimeException e) {
             LOG.d(LOG_TAG, "InAppBrowser: Error loading url "+url+":"+ e.toString());
             return e.toString();
@@ -571,7 +569,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             Boolean wideViewPort = features.get(USER_WIDE_VIEW_PORT);
             if (wideViewPort != null ) {
-                useWideViewPort = wideViewPort.booleanValue();
+		            useWideViewPort = wideViewPort.booleanValue();
             }
         }
 
@@ -586,8 +584,8 @@ public class InAppBrowser extends CordovaPlugin {
              */
             private int dpToPixels(int dipValue) {
                 int value = (int) TypedValue.applyDimension( TypedValue.COMPLEX_UNIT_DIP,
-                        (float) dipValue,
-                        cordova.getActivity().getResources().getDisplayMetrics()
+                                                            (float) dipValue,
+                                                            cordova.getActivity().getResources().getDisplayMetrics()
                 );
 
                 return value;
@@ -695,8 +693,8 @@ public class InAppBrowser extends CordovaPlugin {
                     public boolean onKey(View v, int keyCode, KeyEvent event) {
                         // If the event is a key-down event on the "enter" button
                         if ((event.getAction() == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                            navigate(edittext.getText().toString());
-                            return true;
+                          navigate(edittext.getText().toString());
+                          return true;
                         }
                         return false;
                     }
@@ -731,8 +729,7 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView = new WebView(cordova.getActivity());
                 inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
                 inAppWebView.setId(Integer.valueOf(6));
-
-                // File Chooser Implemented ChromeClient
+// File Chooser Implemented ChromeClient
                 inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
                     // For Android 5.0+
                     public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
@@ -783,7 +780,6 @@ public class InAppBrowser extends CordovaPlugin {
                     }
 
                 });
-
                 WebViewClient client = new InAppBrowserClient(thatWebView, edittext);
                 inAppWebView.setWebViewClient(client);
                 WebSettings settings = inAppWebView.getSettings();
@@ -1035,7 +1031,7 @@ public class InAppBrowser extends CordovaPlugin {
             // Update the UI if we haven't already
             if (!newloc.equals(edittext.getText().toString())) {
                 edittext.setText(newloc);
-            }
+             }
 
             try {
                 JSONObject obj = new JSONObject();
@@ -1046,6 +1042,7 @@ public class InAppBrowser extends CordovaPlugin {
                 LOG.e(LOG_TAG, "URI passed in has caused a JSON error.");
             }
         }
+
 
 
         public void onPageFinished(WebView view, String url) {

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -729,7 +729,7 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView = new WebView(cordova.getActivity());
                 inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
                 inAppWebView.setId(Integer.valueOf(6));
-// File Chooser Implemented ChromeClient
+                // File Chooser Implemented ChromeClient
                 inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
                     // For Android 5.0+
                     public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -894,7 +894,7 @@ public class InAppBrowser extends CordovaPlugin {
 
     /**
      * Receive File Data from File Chooser
-     * 
+     *
      * @param requestCode the requested code from chromeclient
      * @param resultCode the result code returned from android system
      * @param intent the data from android file chooser


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This PR enables default action for input[type=file] at inappbrowser.
Which means, input[type=file] opens native file chooser in android.

### What testing has been done on this change?
I tested input[type=file] element to open file chooser.
And it worked beautifully :D

### Checklist
- [ v ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ v ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ X ] Added automated test coverage as appropriate for this change.