### PR TITLE
CB-12364 [Windows] Inappbrowser inject file manual tests are not working

### DIFF
--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -313,7 +313,8 @@ var IAB = {
             }
 
             if (isWebViewAvailable && browserWrap && popup) {
-                var uri = new Windows.Foundation.Uri(filePath);
+                // CB-12364 getFileFromApplicationUriAsync does not support ms-appx-web
+                var uri = new Windows.Foundation.Uri(filePath.replace('ms-appx-web:', 'ms-appx:'));
                 Windows.Storage.StorageFile.getFileFromApplicationUriAsync(uri).done(function (file) {
                     Windows.Storage.FileIO.readTextAsync(file).done(function (code) {
                         var op = popup.invokeScriptAsync("eval", code);
@@ -350,7 +351,8 @@ var IAB = {
             filePath = filePath && urlutil.makeAbsolute(filePath);
 
             if (isWebViewAvailable && browserWrap && popup) {
-                var uri = new Windows.Foundation.Uri(filePath);
+                // CB-12364 getFileFromApplicationUriAsync does not support ms-appx-web
+                var uri = new Windows.Foundation.Uri(filePath.replace('ms-appx-web:', 'ms-appx:'));
                 Windows.Storage.StorageFile.getFileFromApplicationUriAsync(uri).then(function (file) {
                     return Windows.Storage.FileIO.readTextAsync(file);
                 }).done(function (code) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -26,6 +26,10 @@ var cordova = require('cordova');
 var isWindows = cordova.platformId == 'windows';
 
 window.alert = window.alert || navigator.notification.alert;
+if (isWindows && navigator && navigator.notification && navigator.notification.alert) {
+    // window.alert is defined but not functional on UWP
+    window.alert = navigator.notification.alert;
+}
 
 exports.defineAutoTests = function () {
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
- Updates ms-appx-web to ms-appx in inject style/script methods as ms-appx-web is not supported by getFileFromApplicationUriAsync
- Forces to use cordova-plugin-dialogs on Windows as window.alert is non functional

### What testing has been done on this change?
Manual and auto tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
