### PR TITLE
CB-12366: (ios) Reduce tmpWindow level to prevent overlapping statusbar

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -243,7 +243,7 @@
             UIWindow *tmpWindow = [[UIWindow alloc] initWithFrame:frame];
             UIViewController *tmpController = [[UIViewController alloc] init];
             [tmpWindow setRootViewController:tmpController];
-            [tmpWindow setWindowLevel:UIWindowLevelAlert];
+            [tmpWindow setWindowLevel:UIWindowLevelNormal];
 
             [tmpWindow makeKeyAndVisible];
             [tmpController presentViewController:nav animated:YES completion:nil];


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Reduces the window level of the `tmpWindow` introduced in #187 to `UIWindowLevelNormal`. With the window at `UIWindowLevelAlert`, I'm seeing it obscure the iOS status bar when presented.

@manucorporat I'd be curious to know if the higher window level is required to solve the issues you were looking at in #187.

### What testing has been done on this change?

Testing in Simulator iOS 10, Device iOS10.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.