### PR TITLE
Ios style improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ instance, or the system browser.
     - __clearcache__: set to `yes` to have the browser's cookie cache cleared before the new window is opened
     - __clearsessioncache__: set to `yes` to have the session cookie cache cleared before the new window is opened
     - __toolbar__:  set to `yes` or `no` to turn the toolbar on or off for the InAppBrowser (defaults to `yes`)
+    - __toolbarstyle__: set to `default` or `black` to set the [UIBarStyle](https://developer.apple.com/reference/uikit/uibarstyle?language=objc) of the toolbar (defaults to `default`).
     - __enableViewportScale__:  Set to `yes` or `no` to prevent viewport scaling through a meta tag (defaults to `no`).
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).
     - __allowInlineMediaPlayback__: Set to `yes` or `no` to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface. The HTML's `video` element must also include the `webkit-playsinline` attribute (defaults to `no`)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ instance, or the system browser.
     - __clearcache__: set to `yes` to have the browser's cookie cache cleared before the new window is opened
     - __clearsessioncache__: set to `yes` to have the session cookie cache cleared before the new window is opened
     - __toolbar__:  set to `yes` or `no` to turn the toolbar on or off for the InAppBrowser (defaults to `yes`)
+    - __toolbarposition__: Set to `top` or `bottom` (default is `bottom`). Causes the toolbar to be at the top or bottom of the window.
     - __toolbarstyle__: set to `default` or `black` to set the [UIBarStyle](https://developer.apple.com/reference/uikit/uibarstyle?language=objc) of the toolbar (defaults to `default`).
+    - __tintcolor__: set to a hex color string like `ff00ff` to change the tint color used for controls on iOS 7+. If not provided, or set to `default`, controls will be rendered in the default iOS blue, or in white when `toolbarstyle=black` is set.
     - __enableViewportScale__:  Set to `yes` or `no` to prevent viewport scaling through a meta tag (defaults to `no`).
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).
     - __allowInlineMediaPlayback__: Set to `yes` or `no` to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface. The HTML's `video` element must also include the `webkit-playsinline` attribute (defaults to `no`)
@@ -132,7 +134,6 @@ instance, or the system browser.
     - __suppressesIncrementalRendering__: Set to `yes` or `no` to wait until all new view content is received before being rendered (defaults to `no`).
     - __presentationstyle__:  Set to `pagesheet`, `formsheet` or `fullscreen` to set the [presentation style](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalPresentationStyle) (defaults to `fullscreen`).
     - __transitionstyle__: Set to `fliphorizontal`, `crossdissolve` or `coververtical` to set the [transition style](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalTransitionStyle) (defaults to `coververtical`).
-    - __toolbarposition__: Set to `top` or `bottom` (default is `bottom`). Causes the toolbar to be at the top or bottom of the window.
 
     Windows only:
 

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -109,6 +109,9 @@
 @interface CDVInAppBrowserNavigationController : UINavigationController
 
 @property (nonatomic, weak) id <CDVScreenOrientationDelegate> orientationDelegate;
+@property (nonatomic, strong) IBOutlet UIToolbar* bgToolbar;
+
+- (void)setBgToolbarStyle:(UIBarStyle)style;
 
 @end
 

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -56,6 +56,7 @@
 @property (nonatomic, copy) NSString* toolbarstyle;
 @property (nonatomic, copy) NSString* presentationstyle;
 @property (nonatomic, copy) NSString* transitionstyle;
+@property (nonatomic, copy) NSString* tintcolor;
 
 @property (nonatomic, assign) BOOL enableviewportscale;
 @property (nonatomic, assign) BOOL mediaplaybackrequiresuseraction;

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -87,6 +87,7 @@
 @property (nonatomic, strong) IBOutlet UIWebView* webView;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* closeButton;
 @property (nonatomic, strong) IBOutlet UILabel* addressLabel;
+@property (nonatomic, strong) IBOutlet UIView* addressBar;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* backButton;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -53,6 +53,7 @@
 @property (nonatomic, assign) BOOL clearcache;
 @property (nonatomic, assign) BOOL clearsessioncache;
 
+@property (nonatomic, copy) NSString* toolbarstyle;
 @property (nonatomic, copy) NSString* presentationstyle;
 @property (nonatomic, copy) NSString* transitionstyle;
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -545,25 +545,8 @@
     self.closeButton.enabled = YES;
 
     UIBarButtonItem* flexibleSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-
     UIBarButtonItem* fixedSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     fixedSpaceButton.width = 20;
-
-    float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : 0.0;
-    CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);
-
-    self.toolbar = [[UIToolbar alloc] initWithFrame:toolbarFrame];
-    self.toolbar.alpha = 1.000;
-    self.toolbar.autoresizesSubviews = YES;
-    self.toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
-    self.toolbar.barStyle = UIBarStyleBlackOpaque;
-    self.toolbar.clearsContextBeforeDrawing = NO;
-    self.toolbar.clipsToBounds = NO;
-    self.toolbar.contentMode = UIViewContentModeScaleToFill;
-    self.toolbar.hidden = NO;
-    self.toolbar.multipleTouchEnabled = NO;
-    self.toolbar.opaque = NO;
-    self.toolbar.userInteractionEnabled = YES;
 
     CGFloat labelInset = 5.0;
     float locationBarY = toolbarIsAtBottom ? self.view.bounds.size.height - FOOTER_HEIGHT : self.view.bounds.size.height - LOCATIONBAR_HEIGHT;
@@ -610,6 +593,7 @@
 
     self.webView = [self buildWebView];
     self.spinner = [self buildSpinner];
+    self.toolbar = [self buildToolbar];
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
     self.view.backgroundColor = [UIColor grayColor];
@@ -664,6 +648,29 @@
     [spinner stopAnimating];
 
     return spinner;
+}
+
+- (UIToolbar*)buildToolbar
+{
+    BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : 0.0;
+    CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);
+
+    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:toolbarFrame];
+
+    toolbar.alpha = 1.000;
+    toolbar.autoresizesSubviews = YES;
+    toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
+    toolbar.barStyle = [_browserOptions.toolbarstyle isEqualToString:kInAppBrowserToolbarStyleBlack] ? UIBarStyleBlack : UIBarStyleDefault;
+    toolbar.clearsContextBeforeDrawing = NO;
+    toolbar.clipsToBounds = NO;
+    toolbar.contentMode = UIViewContentModeScaleToFill;
+    toolbar.hidden = NO;
+    toolbar.multipleTouchEnabled = NO;
+    toolbar.opaque = NO;
+    toolbar.userInteractionEnabled = YES;
+
+    return toolbar;
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -539,27 +539,19 @@
 - (void)createViews
 {
     // We create the views in code for primarily for ease of upgrades and not requiring an external .xib to be included
-    self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
-    self.closeButton.enabled = YES;
-
     UIBarButtonItem* flexibleSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem* fixedSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     fixedSpaceButton.width = 20;
-
-    NSString* frontArrowString = NSLocalizedString(@"►", nil); // create arrow from Unicode char
-    self.forwardButton = [[UIBarButtonItem alloc] initWithTitle:frontArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goForward:)];
-    self.forwardButton.enabled = YES;
-    self.forwardButton.imageInsets = UIEdgeInsetsZero;
-
-    NSString* backArrowString = NSLocalizedString(@"◄", nil); // create arrow from Unicode char
-    self.backButton = [[UIBarButtonItem alloc] initWithTitle:backArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goBack:)];
-    self.backButton.enabled = YES;
-    self.backButton.imageInsets = UIEdgeInsetsZero;
 
     self.webView = [self buildWebView];
     self.spinner = [self buildSpinner];
     self.addressLabel = [self buildAddressLabel];
     self.toolbar = [self buildToolbar];
+
+    self.closeButton = [self buildCloseButton];
+    self.forwardButton = [self buildForwardButton];
+    self.backButton = [self buildBackButton];
+
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
     self.view.backgroundColor = [UIColor grayColor];
@@ -627,7 +619,7 @@
     toolbar.alpha = 1.000;
     toolbar.autoresizesSubviews = YES;
     toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
-    toolbar.barStyle = [_browserOptions.toolbarstyle isEqualToString:kInAppBrowserToolbarStyleBlack] ? UIBarStyleBlack : UIBarStyleDefault;
+    toolbar.barStyle = UIBarStyleBlack;
     toolbar.clearsContextBeforeDrawing = NO;
     toolbar.clipsToBounds = NO;
     toolbar.contentMode = UIViewContentModeScaleToFill;
@@ -638,7 +630,6 @@
 
     return toolbar;
 }
-
 
 - (UILabel*)buildAddressLabel
 {
@@ -676,6 +667,33 @@
     addressLabel.userInteractionEnabled = NO;
 
     return addressLabel;
+}
+
+- (UIBarButtonItem*)buildCloseButton
+{
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
+    closeButton.enabled = YES;
+    return closeButton;
+}
+
+- (UIBarButtonItem*)buildForwardButton
+{
+    NSString* frontArrowString = NSLocalizedString(@"►", nil); // create arrow from Unicode char
+    UIBarButtonItem *forwardButton = [[UIBarButtonItem alloc] initWithTitle:frontArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goForward:)];
+    forwardButton.enabled = YES;
+    forwardButton.imageInsets = UIEdgeInsetsZero;
+
+    return forwardButton;
+}
+
+- (UIBarButtonItem*)buildBackButton
+{
+    NSString* backArrowString = NSLocalizedString(@"◄", nil); // create arrow from Unicode char
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:backArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goBack:)];
+    backButton.enabled = YES;
+    backButton.imageInsets = UIEdgeInsetsZero;
+
+    return backButton;
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -624,7 +624,6 @@
     toolbar.alpha = 1.000;
     toolbar.autoresizesSubviews = YES;
     toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
-    toolbar.barStyle = toolbarIsDark ? UIBarStyleBlack : UIBarStyleDefault;
     toolbar.clearsContextBeforeDrawing = NO;
     toolbar.clipsToBounds = NO;
     toolbar.contentMode = UIViewContentModeScaleToFill;
@@ -632,6 +631,13 @@
     toolbar.multipleTouchEnabled = NO;
     toolbar.opaque = NO;
     toolbar.userInteractionEnabled = YES;
+
+    if (toolbarIsDark) {
+        toolbar.barStyle = UIBarStyleBlack;
+        toolbar.tintColor = [UIColor whiteColor];
+    } else {
+        toolbar.barStyle = UIBarStyleDefault;
+    }
 
     return toolbar;
 }

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -540,20 +540,6 @@
 {
     // We create the views in code for primarily for ease of upgrades and not requiring an external .xib to be included
     BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    self.spinner.alpha = 1.000;
-    self.spinner.autoresizesSubviews = YES;
-    self.spinner.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin);
-    self.spinner.clearsContextBeforeDrawing = NO;
-    self.spinner.clipsToBounds = NO;
-    self.spinner.contentMode = UIViewContentModeScaleToFill;
-    self.spinner.frame = CGRectMake(CGRectGetMidX(self.webView.frame), CGRectGetMidY(self.webView.frame), 20.0, 20.0);
-    self.spinner.hidden = NO;
-    self.spinner.hidesWhenStopped = YES;
-    self.spinner.multipleTouchEnabled = NO;
-    self.spinner.opaque = NO;
-    self.spinner.userInteractionEnabled = NO;
-    [self.spinner stopAnimating];
 
     self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
     self.closeButton.enabled = YES;
@@ -623,6 +609,7 @@
 
 
     self.webView = [self buildWebView];
+    self.spinner = [self buildSpinner];
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
     self.view.backgroundColor = [UIColor grayColor];
@@ -655,6 +642,28 @@
     webView.userInteractionEnabled = YES;
 
     return webView;
+}
+
+- (UIActivityIndicatorView*)buildSpinner
+{
+    UIActivityIndicatorView *spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+
+    spinner.alpha = 1.000;
+    spinner.autoresizesSubviews = YES;
+    spinner.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleRightMargin);
+    spinner.clearsContextBeforeDrawing = NO;
+    spinner.clipsToBounds = NO;
+    spinner.contentMode = UIViewContentModeScaleToFill;
+    spinner.frame = CGRectMake(CGRectGetMidX(self.webView.frame), CGRectGetMidY(self.webView.frame), 20.0, 20.0);
+    spinner.hidden = NO;
+    spinner.hidesWhenStopped = YES;
+    spinner.multipleTouchEnabled = NO;
+    spinner.opaque = NO;
+    spinner.userInteractionEnabled = NO;
+
+    [spinner stopAnimating];
+
+    return spinner;
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -569,10 +569,7 @@
 
 - (UIWebView*)buildWebView
 {
-    CGRect webViewBounds = self.view.bounds;
-    webViewBounds.size.height -= _browserOptions.location ? FOOTER_HEIGHT : TOOLBAR_HEIGHT;
-
-    UIWebView *webView = [[UIWebView alloc] initWithFrame:webViewBounds];
+    UIWebView *webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
 
     webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -682,8 +682,8 @@
 
 - (UIBarButtonItem*)buildForwardButton
 {
-    NSString* frontArrowString = NSLocalizedString(@"►", nil); // create arrow from Unicode char
-    UIBarButtonItem *forwardButton = [[UIBarButtonItem alloc] initWithTitle:frontArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goForward:)];
+    UIImage *forwardArrow = [self drawForwardArrow];
+    UIBarButtonItem *forwardButton = [[UIBarButtonItem alloc] initWithImage:forwardArrow style:UIBarButtonItemStylePlain target:self action:@selector(goForward:)];
     forwardButton.enabled = YES;
     forwardButton.imageInsets = UIEdgeInsetsZero;
 
@@ -692,12 +692,41 @@
 
 - (UIBarButtonItem*)buildBackButton
 {
-    NSString* backArrowString = NSLocalizedString(@"◄", nil); // create arrow from Unicode char
-    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:backArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goBack:)];
+    UIImage *backArrow = [self drawBackArrow];
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithImage:backArrow style:UIBarButtonItemStylePlain target:self action:@selector(goBack:)];
     backButton.enabled = YES;
     backButton.imageInsets = UIEdgeInsetsZero;
 
     return backButton;
+}
+
+- (UIImage*)drawForwardArrow
+{
+    CGSize canvasSize = CGSizeMake(20,20);
+    CGFloat scale = [UIScreen mainScreen].scale;
+
+    canvasSize.width *= scale;
+    canvasSize.height *= scale;
+
+    UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    CGContextBeginPath(context);
+    CGContextMoveToPoint(   context, canvasSize.width * 3.0/10.0, canvasSize.height * 2.8/10.0);
+    CGContextAddLineToPoint(context, canvasSize.width * 5.0/10.0, canvasSize.height * 5.0/10.0);
+    CGContextAddLineToPoint(context, canvasSize.width * 3.0/10.0, canvasSize.height * 7.2/10.0);
+
+    CGContextSetLineWidth(context, (scale > 1.0 ? 0.75 * scale : 1.0));
+    CGContextSetStrokeColorWithColor(context, [UIColor blackColor].CGColor);
+    CGContextStrokePath(context);
+
+    return UIGraphicsGetImageFromCurrentImageContext();
+}
+
+-(UIImage*)drawBackArrow
+{
+    UIImage *forwardArrow = [self drawForwardArrow];
+    return [UIImage imageWithCGImage:forwardArrow.CGImage scale:forwardArrow.scale orientation:UIImageOrientationUpMirrored];
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -236,6 +236,7 @@
     nav.orientationDelegate = self.inAppBrowserViewController;
     nav.navigationBarHidden = YES;
     nav.modalPresentationStyle = self.inAppBrowserViewController.modalPresentationStyle;
+    [nav setBgToolbarStyle:self.inAppBrowserViewController.toolbar.barStyle];
 
     __weak CDVInAppBrowser* weakSelf = self;
 
@@ -1133,13 +1134,19 @@
     statusBarFrame.size.height = STATUSBAR_HEIGHT;
     // simplified from: http://stackoverflow.com/a/25669695/219684
 
-    UIToolbar* bgToolbar = [[UIToolbar alloc] initWithFrame:statusBarFrame];
-    bgToolbar.barStyle = UIBarStyleDefault;
-    [bgToolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
-    [self.view addSubview:bgToolbar];
+    self.bgToolbar = [[UIToolbar alloc] initWithFrame:statusBarFrame];
+    self.bgToolbar.barStyle = UIBarStyleDefault;
+    [self.bgToolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
+    [self.view addSubview:self.bgToolbar];
 
     [super viewDidLoad];
 }
+
+- (void)setBgToolbarStyle:(UIBarStyle)style
+{
+    self.bgToolbar.barStyle = style;
+}
+
 
 - (CGRect) invertFrameIfNeeded:(CGRect)rect {
     // We need to invert since on iOS 7 frames are always in Portrait context

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -539,28 +539,7 @@
 - (void)createViews
 {
     // We create the views in code for primarily for ease of upgrades and not requiring an external .xib to be included
-
-    CGRect webViewBounds = self.view.bounds;
     BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-    webViewBounds.size.height -= _browserOptions.location ? FOOTER_HEIGHT : TOOLBAR_HEIGHT;
-    self.webView = [[UIWebView alloc] initWithFrame:webViewBounds];
-
-    self.webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-
-    [self.view addSubview:self.webView];
-    [self.view sendSubviewToBack:self.webView];
-
-    self.webView.delegate = _webViewDelegate;
-    self.webView.backgroundColor = [UIColor whiteColor];
-
-    self.webView.clearsContextBeforeDrawing = YES;
-    self.webView.clipsToBounds = YES;
-    self.webView.contentMode = UIViewContentModeScaleToFill;
-    self.webView.multipleTouchEnabled = YES;
-    self.webView.opaque = YES;
-    self.webView.scalesPageToFit = NO;
-    self.webView.userInteractionEnabled = YES;
-
     self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
     self.spinner.alpha = 1.000;
     self.spinner.autoresizesSubviews = YES;
@@ -642,12 +621,40 @@
     self.backButton.enabled = YES;
     self.backButton.imageInsets = UIEdgeInsetsZero;
 
+
+    self.webView = [self buildWebView];
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
     self.view.backgroundColor = [UIColor grayColor];
+
+    [self.view addSubview:self.webView];
+    [self.view sendSubviewToBack:self.webView];
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];
+}
+
+- (UIWebView*)buildWebView
+{
+    CGRect webViewBounds = self.view.bounds;
+    webViewBounds.size.height -= _browserOptions.location ? FOOTER_HEIGHT : TOOLBAR_HEIGHT;
+
+    UIWebView *webView = [[UIWebView alloc] initWithFrame:webViewBounds];
+
+    webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+
+    webView.delegate = _webViewDelegate;
+    webView.backgroundColor = [UIColor whiteColor];
+
+    webView.clearsContextBeforeDrawing = YES;
+    webView.clipsToBounds = YES;
+    webView.contentMode = UIViewContentModeScaleToFill;
+    webView.multipleTouchEnabled = YES;
+    webView.opaque = YES;
+    webView.scalesPageToFit = NO;
+    webView.userInteractionEnabled = YES;
+
+    return webView;
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -549,8 +549,10 @@
 
     self.webView = [self buildWebView];
     self.spinner = [self buildSpinner];
-    self.addressLabel = [self buildAddressLabel];
     self.toolbar = [self buildToolbar];
+
+    self.addressLabel = [self buildAddressLabel];
+    self.addressBar = [self buildAddressBar:self.addressLabel];
 
     self.closeButton = [self buildCloseButton];
     self.forwardButton = [self buildForwardButton];
@@ -563,7 +565,7 @@
     [self.view addSubview:self.webView];
     [self.view sendSubviewToBack:self.webView];
     [self.view addSubview:self.toolbar];
-    [self.view addSubview:self.addressLabel];
+    [self.view addSubview:self.addressBar];
     [self.view addSubview:self.spinner];
 }
 
@@ -639,13 +641,21 @@
     return toolbar;
 }
 
+- (UIView*)buildAddressBar:(UILabel*)addressLabel
+{
+    BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    float locationBarY = toolbarIsAtBottom ? self.view.bounds.size.height - FOOTER_HEIGHT : self.view.bounds.size.height - LOCATIONBAR_HEIGHT;
+    UIView *addressBar = [[UIView alloc] initWithFrame:CGRectMake(0, locationBarY, self.view.bounds.size.width, LOCATIONBAR_HEIGHT)];
+    addressBar.backgroundColor = [UIColor lightGrayColor];
+
+    [addressBar addSubview:addressLabel];
+    return addressBar;
+}
+
 - (UILabel*)buildAddressLabel
 {
     CGFloat labelInset = 5.0;
-    BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-    float locationBarY = toolbarIsAtBottom ? self.view.bounds.size.height - FOOTER_HEIGHT : self.view.bounds.size.height - LOCATIONBAR_HEIGHT;
-
-    UILabel *addressLabel = [[UILabel alloc] initWithFrame:CGRectMake(labelInset, locationBarY, self.view.bounds.size.width - labelInset, LOCATIONBAR_HEIGHT)];
+    UILabel *addressLabel = [[UILabel alloc] initWithFrame:CGRectMake(labelInset, 0, self.view.bounds.size.width - (2.0 * labelInset), LOCATIONBAR_HEIGHT)];
     addressLabel.adjustsFontSizeToFitWidth = NO;
     addressLabel.alpha = 1.000;
     addressLabel.autoresizesSubviews = YES;
@@ -671,7 +681,7 @@
     addressLabel.shadowOffset = CGSizeMake(0.0, -1.0);
     addressLabel.text = NSLocalizedString(@"Loading...", nil);
     addressLabel.textAlignment = NSTextAlignmentLeft;
-    addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
+    addressLabel.textColor = [UIColor blackColor];
     addressLabel.userInteractionEnabled = NO;
 
     return addressLabel;
@@ -754,17 +764,17 @@
 
 - (void)showLocationBar:(BOOL)show
 {
-    CGRect locationbarFrame = self.addressLabel.frame;
+    CGRect locationbarFrame = self.addressBar.frame;
 
     BOOL toolbarVisible = !self.toolbar.hidden;
 
     // prevent double show/hide
-    if (show == !(self.addressLabel.hidden)) {
+    if (show == !(self.addressBar.hidden)) {
         return;
     }
 
     if (show) {
-        self.addressLabel.hidden = NO;
+        self.addressBar.hidden = NO;
 
         if (toolbarVisible) {
             // toolBar at the bottom, leave as is
@@ -775,7 +785,7 @@
             [self setWebViewFrame:webViewBounds];
 
             locationbarFrame.origin.y = webViewBounds.size.height;
-            self.addressLabel.frame = locationbarFrame;
+            self.addressBar.frame = locationbarFrame;
         } else {
             // no toolBar, so put locationBar at the bottom
 
@@ -784,10 +794,10 @@
             [self setWebViewFrame:webViewBounds];
 
             locationbarFrame.origin.y = webViewBounds.size.height;
-            self.addressLabel.frame = locationbarFrame;
+            self.addressBar.frame = locationbarFrame;
         }
     } else {
-        self.addressLabel.hidden = YES;
+        self.addressBar.hidden = YES;
 
         if (toolbarVisible) {
             // locationBar is on top of toolBar, hide locationBar
@@ -806,9 +816,9 @@
 - (void)showToolBar:(BOOL)show : (NSString *) toolbarPosition
 {
     CGRect toolbarFrame = self.toolbar.frame;
-    CGRect locationbarFrame = self.addressLabel.frame;
+    CGRect locationbarFrame = self.addressBar.frame;
 
-    BOOL locationbarVisible = !self.addressLabel.hidden;
+    BOOL locationbarVisible = !self.addressBar.hidden;
 
     // prevent double show/hide
     if (show == !(self.toolbar.hidden)) {
@@ -824,7 +834,7 @@
             // put toolBar at the bottom
             webViewBounds.size.height -= FOOTER_HEIGHT;
             locationbarFrame.origin.y = webViewBounds.size.height;
-            self.addressLabel.frame = locationbarFrame;
+            self.addressBar.frame = locationbarFrame;
             self.toolbar.frame = toolbarFrame;
         } else {
             // no locationBar, so put toolBar at the bottom
@@ -856,7 +866,7 @@
 
             // move locationBar down
             locationbarFrame.origin.y = webViewBounds.size.height;
-            self.addressLabel.frame = locationbarFrame;
+            self.addressBar.frame = locationbarFrame;
         } else {
             // no locationBar, expand webView to screen dimensions
             [self setWebViewFrame:self.view.bounds];

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -28,6 +28,9 @@
 #define    kInAppBrowserToolbarBarPositionBottom @"bottom"
 #define    kInAppBrowserToolbarBarPositionTop @"top"
 
+#define    kInAppBrowserToolbarStyleDefault @"default"
+#define    kInAppBrowserToolbarStyleBlack @"black"
+
 #define    TOOLBAR_HEIGHT 44.0
 #define    STATUSBAR_HEIGHT 20.0
 #define    LOCATIONBAR_HEIGHT 21.0
@@ -554,7 +557,7 @@
 
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
-    self.view.backgroundColor = [UIColor grayColor];
+    self.view.backgroundColor = [UIColor whiteColor];
 
     [self.view addSubview:self.webView];
     [self.view sendSubviewToBack:self.webView];
@@ -611,6 +614,7 @@
 - (UIToolbar*)buildToolbar
 {
     BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    BOOL toolbarIsDark = [_browserOptions.toolbarstyle isEqualToString:kInAppBrowserToolbarStyleBlack];
     float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : 0.0;
     CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);
 
@@ -619,7 +623,7 @@
     toolbar.alpha = 1.000;
     toolbar.autoresizesSubviews = YES;
     toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
-    toolbar.barStyle = UIBarStyleBlack;
+    toolbar.barStyle = toolbarIsDark ? UIBarStyleBlack : UIBarStyleDefault;
     toolbar.clearsContextBeforeDrawing = NO;
     toolbar.clipsToBounds = NO;
     toolbar.contentMode = UIViewContentModeScaleToFill;
@@ -1033,6 +1037,7 @@
         self.toolbarposition = kInAppBrowserToolbarBarPositionBottom;
         self.clearcache = NO;
         self.clearsessioncache = NO;
+        self.toolbarstyle = kInAppBrowserToolbarStyleDefault;
 
         self.enableviewportscale = NO;
         self.mediaplaybackrequiresuseraction = NO;

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -875,7 +875,8 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-    return UIStatusBarStyleDefault;
+    BOOL toolbarIsDark = [_browserOptions.toolbarstyle isEqualToString:kInAppBrowserToolbarStyleBlack];
+    return toolbarIsDark ? UIStatusBarStyleLightContent : UIStatusBarStyleDefault;
 }
 
 - (BOOL)prefersStatusBarHidden {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -539,46 +539,12 @@
 - (void)createViews
 {
     // We create the views in code for primarily for ease of upgrades and not requiring an external .xib to be included
-    BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-
     self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
     self.closeButton.enabled = YES;
 
     UIBarButtonItem* flexibleSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem* fixedSpaceButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     fixedSpaceButton.width = 20;
-
-    CGFloat labelInset = 5.0;
-    float locationBarY = toolbarIsAtBottom ? self.view.bounds.size.height - FOOTER_HEIGHT : self.view.bounds.size.height - LOCATIONBAR_HEIGHT;
-
-    self.addressLabel = [[UILabel alloc] initWithFrame:CGRectMake(labelInset, locationBarY, self.view.bounds.size.width - labelInset, LOCATIONBAR_HEIGHT)];
-    self.addressLabel.adjustsFontSizeToFitWidth = NO;
-    self.addressLabel.alpha = 1.000;
-    self.addressLabel.autoresizesSubviews = YES;
-    self.addressLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
-    self.addressLabel.backgroundColor = [UIColor clearColor];
-    self.addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
-    self.addressLabel.clearsContextBeforeDrawing = YES;
-    self.addressLabel.clipsToBounds = YES;
-    self.addressLabel.contentMode = UIViewContentModeScaleToFill;
-    self.addressLabel.enabled = YES;
-    self.addressLabel.hidden = NO;
-    self.addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-
-    if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumScaleFactor:")]) {
-        [self.addressLabel setValue:@(10.0/[UIFont labelFontSize]) forKey:@"minimumScaleFactor"];
-    } else if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumFontSize:")]) {
-        [self.addressLabel setValue:@(10.0) forKey:@"minimumFontSize"];
-    }
-
-    self.addressLabel.multipleTouchEnabled = NO;
-    self.addressLabel.numberOfLines = 1;
-    self.addressLabel.opaque = NO;
-    self.addressLabel.shadowOffset = CGSizeMake(0.0, -1.0);
-    self.addressLabel.text = NSLocalizedString(@"Loading...", nil);
-    self.addressLabel.textAlignment = NSTextAlignmentLeft;
-    self.addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
-    self.addressLabel.userInteractionEnabled = NO;
 
     NSString* frontArrowString = NSLocalizedString(@"►", nil); // create arrow from Unicode char
     self.forwardButton = [[UIBarButtonItem alloc] initWithTitle:frontArrowString style:UIBarButtonItemStylePlain target:self action:@selector(goForward:)];
@@ -590,9 +556,9 @@
     self.backButton.enabled = YES;
     self.backButton.imageInsets = UIEdgeInsetsZero;
 
-
     self.webView = [self buildWebView];
     self.spinner = [self buildSpinner];
+    self.addressLabel = [self buildAddressLabel];
     self.toolbar = [self buildToolbar];
     [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
 
@@ -671,6 +637,45 @@
     toolbar.userInteractionEnabled = YES;
 
     return toolbar;
+}
+
+
+- (UILabel*)buildAddressLabel
+{
+    CGFloat labelInset = 5.0;
+    BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    float locationBarY = toolbarIsAtBottom ? self.view.bounds.size.height - FOOTER_HEIGHT : self.view.bounds.size.height - LOCATIONBAR_HEIGHT;
+
+    UILabel *addressLabel = [[UILabel alloc] initWithFrame:CGRectMake(labelInset, locationBarY, self.view.bounds.size.width - labelInset, LOCATIONBAR_HEIGHT)];
+    addressLabel.adjustsFontSizeToFitWidth = NO;
+    addressLabel.alpha = 1.000;
+    addressLabel.autoresizesSubviews = YES;
+    addressLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
+    addressLabel.backgroundColor = [UIColor clearColor];
+    addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
+    addressLabel.clearsContextBeforeDrawing = YES;
+    addressLabel.clipsToBounds = YES;
+    addressLabel.contentMode = UIViewContentModeScaleToFill;
+    addressLabel.enabled = YES;
+    addressLabel.hidden = NO;
+    addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+
+    if ([addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumScaleFactor:")]) {
+        [addressLabel setValue:@(10.0/[UIFont labelFontSize]) forKey:@"minimumScaleFactor"];
+    } else if ([addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumFontSize:")]) {
+        [addressLabel setValue:@(10.0) forKey:@"minimumFontSize"];
+    }
+
+    addressLabel.multipleTouchEnabled = NO;
+    addressLabel.numberOfLines = 1;
+    addressLabel.opaque = NO;
+    addressLabel.shadowOffset = CGSizeMake(0.0, -1.0);
+    addressLabel.text = NSLocalizedString(@"Loading...", nil);
+    addressLabel.textAlignment = NSTextAlignmentLeft;
+    addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
+    addressLabel.userInteractionEnabled = NO;
+
+    return addressLabel;
 }
 
 - (void) setWebViewFrame : (CGRect) frame {

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -31,6 +31,8 @@
 #define    kInAppBrowserToolbarStyleDefault @"default"
 #define    kInAppBrowserToolbarStyleBlack @"black"
 
+#define    kInAppBrowserTintColorDefault @"default"
+
 #define    TOOLBAR_HEIGHT 44.0
 #define    STATUSBAR_HEIGHT 20.0
 #define    LOCATIONBAR_HEIGHT 21.0
@@ -562,6 +564,20 @@
 
     self.view.backgroundColor = [UIColor whiteColor];
 
+    if (IsAtLeastiOSVersion(@"7.0")) {
+        if (![_browserOptions.tintcolor isEqualToString:kInAppBrowserTintColorDefault]) {
+            unsigned hexValue = 0;
+            NSScanner *scanner = [NSScanner scannerWithString:_browserOptions.tintcolor];
+            [scanner scanHexInt:&hexValue];
+            self.view.tintColor = [UIColor colorWithRed:((hexValue & 0xFF0000) >> 16) / 255.0
+                                                  green:((hexValue & 0xFF00) >> 8) / 255.0
+                                                   blue:( hexValue & 0xFF ) / 255.0
+                                                  alpha:1.0];
+        } else if ([_browserOptions.toolbarstyle isEqualToString:kInAppBrowserToolbarStyleBlack]) {
+            self.view.tintColor = [UIColor whiteColor];
+        }
+    }
+
     [self.view addSubview:self.webView];
     [self.view sendSubviewToBack:self.webView];
     [self.view addSubview:self.toolbar];
@@ -630,13 +646,7 @@
     toolbar.multipleTouchEnabled = NO;
     toolbar.opaque = NO;
     toolbar.userInteractionEnabled = YES;
-
-    if (toolbarIsDark) {
-        toolbar.barStyle = UIBarStyleBlack;
-        toolbar.tintColor = [UIColor whiteColor];
-    } else {
-        toolbar.barStyle = UIBarStyleDefault;
-    }
+    toolbar.barStyle = toolbarIsDark ? UIBarStyleBlack : UIBarStyleDefault;
 
     return toolbar;
 }
@@ -1082,6 +1092,7 @@
         self.clearcache = NO;
         self.clearsessioncache = NO;
         self.toolbarstyle = kInAppBrowserToolbarStyleDefault;
+        self.tintcolor = kInAppBrowserTintColorDefault;
 
         self.enableviewportscale = NO;
         self.mediaplaybackrequiresuseraction = NO;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

I've been working on a branch that brings several visual and configuration improvements to the iOS InAppBrowser view, along with a little refactoring of the view setup code.

This PR:
* breaks up the large `CDVInAppBrowserViewController createView` method into several smaller helper methods to handle the creation of individual subviews
* gives the `addressLabel` a wrapping view to provide flexibility of background color / padding
* changes the default toolbar style from `UIBarStyleBlackOpaque` to `UIBarStyleDefault` to match the system default
* adds a `toolbarstyle` configuration option that accepts `default` or `black`
* sets the status bar style and background color to match the toolbarstyle, so that top toolbars can blend nicely into the status bar
* replaces the unicode navigation arrows (◄►) with drawn arrows that match those used in Safari
* adds a `tintcolor` configuration option that accepts hex strings like `f8a027`. If not provided, or set to `default`, controls will be rendered in the default iOS blue, or in white when `toolbarstyle=black` is set.

### What testing has been done on this change?

Simulator and device iOS 10. Ran plugin auto tests locally.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

### Screenshots!

#### Old Default

<img src="https://cloud.githubusercontent.com/assets/13192/22090934/093ac000-dda9-11e6-8e95-09ca9929fa68.png" width=250>

---

#### New Default 

<img src="https://cloud.githubusercontent.com/assets/13192/22091065/b22beb12-dda9-11e6-8d6c-29b2b5715869.png" width=250>

---

#### `location=no`

<img src="https://cloud.githubusercontent.com/assets/13192/22091092/ef0b84f2-dda9-11e6-82e8-405aa7ccde9a.png" width=250>

---

#### `location=no,toolbarposition=top`

<img src="https://cloud.githubusercontent.com/assets/13192/22091124/1bcdd7d8-ddaa-11e6-860b-873c486e627a.png" width=250>

---

#### `location=no,toolbarposition=top,tintcolor=F8A027`

<img src="https://cloud.githubusercontent.com/assets/13192/22091138/32e9555a-ddaa-11e6-9801-8dd57863f2eb.png" width=250>

---

#### `location=no,toolbarposition=top,tintcolor=F8A027,toolbarstyle=black`

<img src="https://cloud.githubusercontent.com/assets/13192/22091158/4f9a646e-ddaa-11e6-9201-74f672a1611e.png" width=250>

---

#### `location=no,toolbarposition=top,toolbarstyle=black`

<img src="https://cloud.githubusercontent.com/assets/13192/22091192/8726d4b2-ddaa-11e6-8462-63f300d840e0.png" width=250>

---

#### `location=no,toolbarstyle=black`

<img src="https://cloud.githubusercontent.com/assets/13192/22091204/9ce2720c-ddaa-11e6-9799-bd57497cfbeb.png" width=250>

---