### PR TITLE
CB-12468 added ability to set|get default options;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ Thumbs.db
 *.idea
 
 node_modules
-
+.idea/
 
 
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Report issues with this plugin on the [Apache Cordova issue tracker](https://iss
 
 If you want all page loads in your app to go through the InAppBrowser, you can
 simply hook `window.open` during initialization.  For example:
-
+```javascript
     document.addEventListener("deviceready", onDeviceReady, false);
     function onDeviceReady() {
         window.open = cordova.InAppBrowser.open;
     }
-
+```
 ## cordova.InAppBrowser.open
 
 Opens a URL in a new `InAppBrowser` instance, the current browser
@@ -203,6 +203,27 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
 - executeScript
 - insertCSS
 
+## cordova.InAppBrowser.setDefaultOptions
+
+> Set default options for all instances of InAppBrowser;
+    
+    cordova.InAppBrowser.setDefaultOptions(options);
+
+## Example
+All options that have required attrinbute will be used even if another options will be provided in window.open.
+In other cases new and default will merge together
+
+```javascript
+    cordova.InAppBrowser.setDefaultOptions('location=no(required),toolbar=yes(required),closebuttoncaption=Close');
+```
+
+## cordova.InAppBrowser.setDefaultOptions
+
+> Get default options for all instances of InAppBrowser;
+    
+    cordova.InAppBrowser.getDefaultOptions();
+    
+    
 ## InAppBrowser.addEventListener
 
 > Adds a listener for an event from the `InAppBrowser`. (Only available when the target is set to `'_blank'`)

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,14 +30,20 @@
     <issue>https://issues.apache.org/jira/browse/CB/component/12320641</issue>
 
     <engines>
-      <engine name="cordova" version=">=3.1.0" /><!-- Needs cordova/urlutil -->
+        <engine name="cordova" version=">=3.1.0" /><!-- Needs cordova/urlutil -->
     </engines>
 
     <!-- android -->
     <platform name="android">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
+            <runs />
+        </js-module>
+        <js-module src="www/open.js" name="open">
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
+        </js-module>
+        <js-module src="www/options.js" name="options">
+            <merges target="cordova.InAppBrowser"/>
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="InAppBrowser">
@@ -70,8 +76,14 @@
     <!-- ios -->
     <platform name="ios">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
+            <runs />
+        </js-module>
+        <js-module src="www/open.js" name="open">
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
+        </js-module>
+        <js-module src="www/options.js" name="options">
+            <merges target="cordova.InAppBrowser"/>
         </js-module>
         <config-file target="config.xml" parent="/*">
             <feature name="InAppBrowser">
@@ -80,9 +92,9 @@
         </config-file>
 
         <header-file src="src/ios/CDVInAppBrowser.h" />
-	    <source-file src="src/ios/CDVInAppBrowser.m" />
+        <source-file src="src/ios/CDVInAppBrowser.m" />
 
-	    <framework src="CoreGraphics.framework" />
+        <framework src="CoreGraphics.framework" />
     </platform>
 
     <!-- osx -->
@@ -107,6 +119,13 @@
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
         </js-module>
+        <js-module src="www/open.js" name="open">
+            <clobbers target="cordova.InAppBrowser.open" />
+            <clobbers target="window.open" />
+        </js-module>
+        <js-module src="www/options.js" name="options">
+            <merges target="cordova.InAppBrowser"/>
+        </js-module>
         <js-module src="src/windows/InAppBrowserProxy.js" name="InAppBrowserProxy">
             <runs />
         </js-module>
@@ -116,8 +135,14 @@
     <!-- browser -->
     <platform name="browser">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
+            <runs />
+        </js-module>
+        <js-module src="www/open.js" name="open">
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
+        </js-module>
+        <js-module src="www/options.js" name="options">
+            <merges target="cordova.InAppBrowser"/>
         </js-module>
         <js-module src="src/browser/InAppBrowserProxy.js" name="InAppBrowserProxy">
             <runs />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,11 @@ interface Window {
  * NOTE: The InAppBrowser window behaves like a standard web browser, and can't access Cordova APIs.
  */
 interface InAppBrowser extends Window {
+
+    options: string;
+    setDefaultOptions(opts: string): void;
+    getDefaultOptions(): string;
+
     onloadstart(type: Event): void;
     onloadstop(type: InAppBrowserEvent): void;
     onloaderror(type: InAppBrowserEvent): void;

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -28,11 +28,9 @@
 
     var exec = require('cordova/exec');
     var channel = require('cordova/channel');
-    var modulemapper = require('cordova/modulemapper');
-    var urlutil = require('cordova/urlutil');
 
-    function InAppBrowser () {
-        this.channels = {
+    function InAppBrowser() {
+       this.channels = {
             'loadstart': channel.create('loadstart'),
             'loadstop': channel.create('loadstop'),
             'loaderror': channel.create('loaderror'),
@@ -40,6 +38,16 @@
             'customscheme': channel.create('customscheme')
         };
     }
+
+    InAppBrowser.options = '';
+
+    InAppBrowser.setDefaultOptions = function (str) {
+        InAppBrowser.options = str || '';
+    };
+
+    InAppBrowser.getDefaultOptions = function () {
+        return InAppBrowser.options || '';
+    };
 
     InAppBrowser.prototype = {
         _eventHandler: function (event) {
@@ -88,28 +96,7 @@
         }
     };
 
-    module.exports = function (strUrl, strWindowName, strWindowFeatures, callbacks) {
-        // Don't catch calls that write to existing frames (e.g. named iframes).
-        if (window.frames && window.frames[strWindowName]) {
-            var origOpenFunc = modulemapper.getOriginalSymbol(window, 'open');
-            return origOpenFunc.apply(window, arguments);
-        }
+    InAppBrowser.prototype.constructor = InAppBrowser;
 
-        strUrl = urlutil.makeAbsolute(strUrl);
-        var iab = new InAppBrowser();
-
-        callbacks = callbacks || {};
-        for (var callbackName in callbacks) {
-            iab.addEventListener(callbackName, callbacks[callbackName]);
-        }
-
-        var cb = function (eventname) {
-            iab._eventHandler(eventname);
-        };
-
-        strWindowFeatures = strWindowFeatures || '';
-
-        exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, strWindowFeatures]);
-        return iab;
-    };
+    module.exports = InAppBrowser;
 })();

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -29,8 +29,8 @@
     var exec = require('cordova/exec');
     var channel = require('cordova/channel');
 
-    function InAppBrowser() {
-       this.channels = {
+    function InAppBrowser () {
+        this.channels = {
             'loadstart': channel.create('loadstart'),
             'loadstop': channel.create('loadstop'),
             'loaderror': channel.create('loaderror'),

--- a/www/open.js
+++ b/www/open.js
@@ -2,13 +2,15 @@
  * Created by SinceTV on 13.02.17.
  */
 var modulemapper = require('cordova/modulemapper');
-var exec         = require('cordova/exec');
-var urlutil      = require('cordova/urlutil');
+var exec = require('cordova/exec');
+var urlutil = require('cordova/urlutil');
 
 var InAppBrowser = require('cordova-plugin-inappbrowser.inappbrowser');
 
 function getOpts (oldOpts, newOpts) {
-    var res = '', keys, priorityBasedOpts;
+    var res = '';
+    var keys;
+    var priorityBasedOpts;
 
     newOpts = newOpts.match(/([^,]+)/g);
 
@@ -23,7 +25,7 @@ function getOpts (oldOpts, newOpts) {
                 return acum;
             }, {});
         keys = Object.keys(priorityBasedOpts);
-        res = keys.map(function(key) {
+        res = keys.map(function (key) {
             return key + '=' + priorityBasedOpts[key];
         }).join(',').replace(/\(required\)/g, '');
     } else {
@@ -32,7 +34,7 @@ function getOpts (oldOpts, newOpts) {
     return res;
 }
 
-module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
+module.exports = function (strUrl, strWindowName, strWindowFeatures, callbacks) {
     // Don't catch calls that write to existing frames (e.g. named iframes).
     var instance = new InAppBrowser();
 
@@ -48,12 +50,12 @@ module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
         instance.addEventListener(callbackName, callbacks[callbackName]);
     }
 
-    var cb = function(eventname) {
+    var cb = function (eventname) {
         instance._eventHandler(eventname);
     };
 
     strWindowFeatures = strWindowFeatures || '';
 
-    exec(cb, cb, "InAppBrowser", "open", [strUrl, strWindowName, getOpts(instance.constructor.getDefaultOptions(), strWindowFeatures)]);
+    exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, getOpts(instance.constructor.getDefaultOptions(), strWindowFeatures)]);
     return instance;
 };

--- a/www/open.js
+++ b/www/open.js
@@ -1,0 +1,59 @@
+/**
+ * Created by SinceTV on 13.02.17.
+ */
+var modulemapper = require('cordova/modulemapper');
+var exec         = require('cordova/exec');
+var urlutil      = require('cordova/urlutil');
+
+var InAppBrowser = require('cordova-plugin-inappbrowser.inappbrowser');
+
+function getOpts (oldOpts, newOpts) {
+    var res = '', keys, priorityBasedOpts;
+
+    newOpts = newOpts.match(/([^,]+)/g);
+
+    if (newOpts) {
+        priorityBasedOpts = oldOpts.split(',')
+            .concat(newOpts)
+            .reduce(function (acum, elem) {
+                var splitted = elem.split('=');
+                if (!acum[splitted[0]] || acum[splitted[0]].indexOf('(required)') === -1) {
+                    acum[splitted[0]] = splitted[1];
+                }
+                return acum;
+            }, {});
+        keys = Object.keys(priorityBasedOpts);
+        res = keys.map(function(key) {
+            return key + '=' + priorityBasedOpts[key];
+        }).join(',').replace(/\(required\)/g, '');
+    } else {
+        res = oldOpts;
+    }
+    return res;
+}
+
+module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
+    // Don't catch calls that write to existing frames (e.g. named iframes).
+    var instance = new InAppBrowser();
+
+    if (window.frames && window.frames[strWindowName]) {
+        var origOpenFunc = modulemapper.getOriginalSymbol(window, 'open');
+        return origOpenFunc.apply(window, arguments);
+    }
+
+    strUrl = urlutil.makeAbsolute(strUrl);
+
+    callbacks = callbacks || {};
+    for (var callbackName in callbacks) {
+        instance.addEventListener(callbackName, callbacks[callbackName]);
+    }
+
+    var cb = function(eventname) {
+        instance._eventHandler(eventname);
+    };
+
+    strWindowFeatures = strWindowFeatures || '';
+
+    exec(cb, cb, "InAppBrowser", "open", [strUrl, strWindowName, getOpts(instance.constructor.getDefaultOptions(), strWindowFeatures)]);
+    return instance;
+};

--- a/www/options.js
+++ b/www/options.js
@@ -3,11 +3,11 @@
  */
 var InAppBrowser = require('cordova-plugin-inappbrowser.inappbrowser');
 module.exports = {
-    setDefaultOptions : function (options) {
+    setDefaultOptions: function (options) {
         InAppBrowser.setDefaultOptions(options);
         return InAppBrowser.getDefaultOptions();
     },
-    getDefaultOptions : function () {
+    getDefaultOptions: function () {
         return InAppBrowser.getDefaultOptions();
     }
 };

--- a/www/options.js
+++ b/www/options.js
@@ -1,0 +1,13 @@
+/**
+ * Created by SinceTV on 13.02.17.
+ */
+var InAppBrowser = require('cordova-plugin-inappbrowser.inappbrowser');
+module.exports = {
+    setDefaultOptions : function (options) {
+        InAppBrowser.setDefaultOptions(options);
+        return InAppBrowser.getDefaultOptions();
+    },
+    getDefaultOptions : function () {
+        return InAppBrowser.getDefaultOptions();
+    }
+};


### PR DESCRIPTION
While using plugin I must set popup features only when calling window.open method. But a lot of libraries (firebase, openFB) use window.open inside their own code where I can't directly menage the features of window to be opened, and on IOS, where we do not a have a 'back' button we could have a problem. For example window, opened with 'toolbar=no' will make app to stack with no ability to close the window. Another thing to be mentioned is when on IOS you use <video inline> attribute, after opening a new window without setting 'allowInlineMediaPlayback=yes' all inline attributes will stop working properly and video will start to open in a fullscreen mode.

So, my proposal is to provide an ability to setDefaultOptions method that will help to prevent external libraries to manage the options of of window to be opened directly. If pass a '(required)' in option like that 'location=no(required)' than any option provided in window.open method will not affect on the default settings.

I tested it in my projects (IOS|Android), and everything works fine;