### PR TITLE
CB-12560: (android) fix null pointer with callback when loading multi…

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -259,7 +259,7 @@ public class InAppBrowser extends CordovaPlugin {
             });
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
             pluginResult.setKeepCallback(true);
-            this.callbackContext.sendPluginResult(pluginResult);
+            callbackContext.sendPluginResult(pluginResult);
         }
         else if (action.equals("hide")) {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
@@ -270,7 +270,7 @@ public class InAppBrowser extends CordovaPlugin {
             });
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
             pluginResult.setKeepCallback(true);
-            this.callbackContext.sendPluginResult(pluginResult);
+            callbackContext.sendPluginResult(pluginResult);
         }
         else {
             return false;
@@ -869,12 +869,13 @@ public class InAppBrowser extends CordovaPlugin {
      * @param status the status code to return to the JavaScript environment
      */
     private void sendUpdate(JSONObject obj, boolean keepCallback, PluginResult.Status status) {
-        if (callbackContext != null) {
+        final CallbackContext localCallbackContext = callbackContext;
+        if (localCallbackContext != null) {
             PluginResult result = new PluginResult(status, obj);
             result.setKeepCallback(keepCallback);
-            callbackContext.sendPluginResult(result);
+            localCallbackContext.sendPluginResult(result);
             if (!keepCallback) {
-                callbackContext = null;
+                this.callbackContext = null;
             }
         }
     }


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
When multiple urls are requested sequentially (such as a monitor script), the object reference to callback could be nulled by another thread causing a NullPointerException.

### What testing has been done on this change?
I have run the automated tests, and successfully ran the application without the crash.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
