### PR TITLE
CB-12266: (browser platform) loadstop event.url is now a string

### DIFF
--- a/src/browser/InAppBrowserProxy.js
+++ b/src/browser/InAppBrowserProxy.js
@@ -31,15 +31,15 @@ var browserWrap,
 
 function attachNavigationEvents(element, callback) {
     var onError = function () {
-        callback({ type: "loaderror", url: this.contentWindow.location}, {keepCallback: true});
+        callback({ type: "loaderror", url: this.contentWindow.location.href}, {keepCallback: true});
     };
 
     element.addEventListener("pageshow", function () {
-        callback({ type: "loadstart", url: this.contentWindow.location}, {keepCallback: true});
+        callback({ type: "loadstart", url: this.contentWindow.location.href}, {keepCallback: true});
     });
 
     element.addEventListener("load", function () {
-        callback({ type: "loadstop", url: this.contentWindow.location}, {keepCallback: true});
+        callback({ type: "loadstop", url: this.contentWindow.location.href}, {keepCallback: true});
     });
 
     element.addEventListener("error", onError);


### PR DESCRIPTION
… instead of an object, aligning it with the other platforms.

### Platforms affected

Browser.

### What does this PR do?

Fixes [CB-12266](https://issues.apache.org/jira/browse/CB-12266): previously in the browser platform, `loadstop` event object's `url` property would be an object and not a string, like the other platforms.

### What testing has been done on this change?

Tested in Chrome on a Mac desktop.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database: [CB-12266](https://issues.apache.org/jira/browse/CB-12266)
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
