### PR TITLE
Enabling Appcache for the android webview

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -800,6 +800,9 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
+                    settings.setAppCacheMaxSize(5 * 1048576);
+                    settings.setAppCachePath(databasePath);
+                    settings.setAppCacheEnabled(true);
                 }
                 settings.setDomStorageEnabled(true);
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -800,7 +800,6 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
-                    settings.setAppCacheMaxSize(5 * 1048576);
                     settings.setAppCachePath(databasePath);
                     settings.setAppCacheEnabled(true);
                 }


### PR DESCRIPTION
Enabling App Caching for the android webview instance. Disabled by default.