### PR TITLE
CB-13791: (android) Add Android support for a footer close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,13 @@ instance, or the system browser.
     - __hidden__: set to `yes` to create the browser and load the page, but not show it. The loadstop event fires when loading is complete. Omit or set to `no` (default) to have the browser open and load normally.
     - __clearcache__: set to `yes` to have the browser's cookie cache cleared before the new window is opened
     - __clearsessioncache__: set to `yes` to have the session cookie cache cleared before the new window is opened
-    - __closebuttoncaption__: set to a string to use as the close buttons caption instead of a X. Note that you need to localize this value yourself.
+    - __closebuttoncaption__: set to a string to use as the close button's caption instead of a X. Note that you need to localize this value yourself.
     - __closebuttoncolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the
     close button color from default, regardless of being a text or default X. Only has effect if user has location set to `yes`.
+    - __footer__: set to `yes` to show a close button in the footer similar to the iOS __Done__ button. 
+    The close button will appear the same as for the header hence use __closebuttoncaption__ and __closebuttoncolor__ to set its properties.
+    - __footercolor__: set to a valid hex color string, for example `#00ff00` or `#CC00ff00` (`#aarrggbb`) , and it will change the footer color from default.
+    Only has effect if user has __footer__ set to `yes`.
     - __hardwareback__: set to `yes` to use the hardware back button to navigate backwards through the `InAppBrowser`'s history. If there is no previous page, the `InAppBrowser` will close.  The default value is `yes`, so you must set it to `no` if you want the back button to simply close the InAppBrowser.
     - __hidenavigationbuttons__: set to `yes` to hide the navigation buttons on the location toolbar, only has effect if user has location set to `yes`. The default value is `no`.
     - __hideurlbar__: set to `yes` to hide the url bar on the location toolbar, only has effect if user has location set to `yes`. The default value is `no`.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### What does this PR do?
Adds support to Android for a footer close button similar to the "Done" button on iOS.

### What testing has been done on this change?
Manual testing as there's no currently no automated tests for platform-specific options.
I've tested all the possible combinations of the new `footer` and `footercolor` options with the related `closebuttoncaption` and `closebuttoncolor` options. The screenshots below illustrate the results:

`location=yes,footer=yes`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147006-2a602f88-cfbe-11e7-9580-438b07236400.png"/>

`location=no,footer=yes`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147147-a60efaba-cfbe-11e7-8132-120179e8b43e.png"/>

`location=yes,footer=yes,closebuttoncaption=Done`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147185-ca8d1e6c-cfbe-11e7-9646-0e1cea52abce.png"/>

`location=no,footer=yes,closebuttoncaption=Done,closebuttoncolor=#0000ff`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147285-1aa7bc54-cfbf-11e7-9b9b-576f0d87ed9a.png"/>

`location=no,footer=yes,footercolor=#0000ff,closebuttoncaption=Done`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147316-3ab511fe-cfbf-11e7-8b19-d1de80ad289e.png"/>

`location=no,footer=yes,footercolor=#00ff00,closebuttoncaption=Done,closebuttoncolor=#0000ff`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147348-581b55c8-cfbf-11e7-9490-c61d83957079.png"/>

`location=no,footer=yes,footercolor=#CC000000,closebuttoncaption=Done,closebuttoncolor=#00FFFF`
<img width="300" src="https://user-images.githubusercontent.com/2345062/33147377-6ec46c6a-cfbf-11e7-969e-a075142133c4.png"/>


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
