### PR TITLE
CB-14048: (android) allowedSchemes check empty string fix

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1114,8 +1114,10 @@ public class InAppBrowser extends CordovaPlugin {
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
             else if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
                 if (allowedSchemes == null) {
-                    String allowed = preferences.getString("AllowedSchemes", "");
-                    allowedSchemes = allowed.split(",");
+                    String allowed = preferences.getString("AllowedSchemes", null);
+                    if(allowed != null) {
+                        allowedSchemes = allowed.split(",");
+                    }
                 }
                 if (allowedSchemes != null) {
                     for (String scheme : allowedSchemes) {


### PR DESCRIPTION
## Motivation

The new AllowSchemes introduced with inappbrowser@3.0.0 doesn't check if  AllowSchemes contains  empty string after having being loaded, respectively only if null, which could lead to error in case a custom scheme is use but not set as white listed schema 

What I mean is that, if no preference would be set in config.xml but a custom scheme would be used (my case) then the variable allowSchemes won't be null but will contains an empty string

Fix for https://issues.apache.org/jira/browse/CB-14048