### PR TITLE
CB-14061: (android) comply with RFC 3986 for custom URL scheme handling

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1112,7 +1112,7 @@ public class InAppBrowser extends CordovaPlugin {
                 }
             }
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
-            else if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
+            else if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[A-Za-z0-9+.-]*://.*?$")) {
                 if (allowedSchemes == null) {
                     String allowed = preferences.getString("AllowedSchemes", "");
                     allowedSchemes = allowed.split(",");


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

This fixes a small regression of #263 to allow more custom URL schemes for android (see comment https://github.com/apache/cordova-plugin-inappbrowser/pull/263#issuecomment-386063556)

### What testing has been done on this change?

Manual testing with a custom URL scheme: `staging+d2d`

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.