### PR TITLE
CB-14190: (windows) Fix bug where double clicking `<select>` exits app

### DIFF
--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -159,10 +159,12 @@ var IAB = {
                     // Save body overflow style to be able to reset it back later
                     bodyOverflowStyle = document.body.style.msOverflowStyle;
 
-                    browserWrap.onclick = function () {
-                        setTimeout(function () {
-                            IAB.close(navigationEventsCallback);
-                        }, 0);
+                    browserWrap.onclick = function (e) {
+                        if (e.target !== popup) {
+                            setTimeout(function () {
+                                IAB.close(navigationEventsCallback);
+                            }, 0);
+                        }
                     };
 
                     document.body.appendChild(browserWrap);


### PR DESCRIPTION
Double clicking on `<select>` elements will no longer exit the application.

### Platforms affected

* Windows.

### What does this PR do?

Previously, there was code which I assume was meant to detect a click outside the webview (and on the browser wrapper), and close the webview if such a click occurs. This makes sense if the webview is treated like a popup, but the code did not check if the target of the click was the webview itself. For whatever reason, double clicking a `<select>` element triggered this behaviour, incorrectly closing the webview when the user is trying to interact with it.

### What testing has been done on this change?

* Tested that double clicking a `<select>` element no longer triggers the exit event.
* Tested that a non-fullscreen inappbrowser still triggers the exit event if clicked outside of.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
