### PR TITLE
fix(android): fix crash for target '_system'

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -279,7 +279,9 @@ public class InAppBrowser extends CordovaPlugin {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    dialog.show();
+                       if(dialog != null){
+                          dialog.show();
+                       }
                 }
             });
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
@@ -290,7 +292,9 @@ public class InAppBrowser extends CordovaPlugin {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    dialog.hide();
+                       if(dialog != null){
+                          dialog.hide();
+                       }
                 }
             });
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);


### PR DESCRIPTION
app was crashing when the opening the links on system browser.(target is '_system').
this issue is fixed.

### Platforms affected
Android

### What does this PR do?
just added the condition to check the dialog is null or not

### What testing has been done on this change?
manual.

### Checklist
-[*] reported on several forms, blogs and its still open bug on ionic 2 or 3 native plugin.
-[*] affected on all versions of the android platform.(custom or stock rom included).
