### PR TITLE
GH-314: (iOS) Fix bug with removing temp UIWindow when browser exits.

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -551,6 +551,12 @@
     }
 
     _previousStatusBarStyle = -1; // this value was reset before reapplying it. caused statusbar to stay black on ios7
+
+    // remove temp UIWindow
+    if (tmpWindow != nil) {
+        [tmpWindow removeFromSuperview];
+        tmpWindow = nil;
+    }
 }
 
 @end


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fixed a bug that the app is not responding after the inappbrowser controller  closed.

### What testing has been done on this change?
Tested on ionic 3 app.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
