### PR TITLE
This lets the default window layering do it's thing. 

### DIFF
--- a/src/ios/CDVUIInAppBrowser.m
+++ b/src/ios/CDVUIInAppBrowser.m
@@ -258,8 +258,6 @@ static CDVUIInAppBrowser* instance = nil;
             }
             UIViewController *tmpController = [[UIViewController alloc] init];
             [tmpWindow setRootViewController:tmpController];
-            double baseWindowLevel = [UIApplication sharedApplication].keyWindow.windowLevel;
-            [tmpWindow setWindowLevel:baseWindowLevel+1];
 
             [tmpWindow makeKeyAndVisible];
             [tmpController presentViewController:nav animated:YES completion:nil];


### PR DESCRIPTION
Fixes #334. Fixes #314.

### Platforms affected
iOS

### What does this PR do?
Resets the window layering back to the default.

### What testing has been done on this change?
Tested with both UIWeb and WKWeb views and dom interaction is maintained correctly through showing a new browser window, and dismissing it.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
