### PR TITLE
iOS CDVWKInAppBrowser evaluateJavascript method randomly gets blocked on ios 12

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -400,29 +400,17 @@ static CDVWKInAppBrowser* instance = nil;
 
 //Synchronus helper for javascript evaluation
 
-- (NSString *)evaluateJavaScript:(NSString *)script {
-    __block NSString *resultString = nil;
-    __block BOOL finished = NO;
+- (void)evaluateJavaScript:(NSString *)script {
     __block NSString* _script = script;
-    
     [self.inAppBrowserViewController.webView evaluateJavaScript:script completionHandler:^(id result, NSError *error) {
         if (error == nil) {
             if (result != nil) {
-                resultString = result;
-                NSLog(@"%@", resultString);
+                NSLog(@"%@", result);
             }
         } else {
             NSLog(@"evaluateJavaScript error : %@ : %@", error.localizedDescription, _script);
         }
-        finished = YES;
     }];
-    
-    while (!finished)
-    {
-        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
-    }
-    
-    return resultString;
 }
 
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION

### Platforms affected
iOS

### What does this PR do?
fix issue[ #340](https://github.com/apache/cordova-plugin-inappbrowser/issues/340) iOS CDVWKInAppBrowser evaluateJavascript method randomly gets blocked on iOS 12

### What testing has been done on this change?
manual testing

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
