### PR TITLE
fix(android): Grant permissions on lollipop to InAppBrowser views (CB-9115)

### DIFF
--- a/src/android/InAppChromeClient.java
+++ b/src/android/InAppChromeClient.java
@@ -24,6 +24,9 @@ import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import android.os.Build;
+import android.annotation.TargetApi;
+import android.webkit.PermissionRequest;
 import android.webkit.JsPromptResult;
 import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
@@ -122,7 +125,7 @@ public class InAppChromeClient extends WebChromeClient {
             else
             {
                 // Anything else with a gap: prefix should get this message
-                LOG.w(LOG_TAG, "InAppBrowser does not support Cordova API calls: " + url + " " + defaultValue); 
+                LOG.w(LOG_TAG, "InAppBrowser does not support Cordova API calls: " + url + " " + defaultValue);
                 result.cancel();
                 return true;
             }
@@ -130,4 +133,9 @@ public class InAppChromeClient extends WebChromeClient {
         return false;
     }
 
+    @Override
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public void onPermissionRequest(PermissionRequest request) {
+        request.grant(request.getResources());
+    }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This patch overrides onPermissionRequest so that getUserMedia can be used inside the InAppBrowser on Lollipop devices.

It is the same fix vbraun did on cordova-android:

https://github.com/apache/cordova-android/pull/178

### What testing has been done on this change?
Manual

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
