### PR TITLE
Example documentation - Fix messageCallBack and beforeloadCallBack function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ function executeScriptCallBack(params) {
 
 }
 
-function beforeloadCallback(params, callback) {
+function beforeloadCallBack(params, callback) {
 
     if (params.url.startsWith("http://www.example.com/")) {
 
@@ -309,7 +309,7 @@ function beforeloadCallback(params, callback) {
 
 }
 
-function messageCallback(params){
+function messageCallBack(params){
     $('#status-message').text("message received: "+params.data.my_message);
 }
 


### PR DESCRIPTION
### What does this PR do?
Update example documentation to correctly reference the CallBack functions for the message and beforeload event listeners.  Changes case from Callback to CallBack.