### PR TITLE
Android: Use evaluateJavascript execute script (not prompt)

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -73,6 +73,7 @@ import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginManager;
 import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -268,11 +269,15 @@ public class InAppBrowser extends CordovaPlugin {
             });
         }
         else if (action.equals("injectScriptCode")) {
-            String jsWrapper = null;
-            if (args.getBoolean(1)) {
-                jsWrapper = String.format("(function(){prompt(JSON.stringify([eval(%%s)]), 'gap-iab://%s')})()", callbackContext.getCallbackId());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && args.getBoolean(1)) {
+                runJavascriptWithResult(args.getString(0), callbackContext);
+            } else {
+                String jsWrapper = null;
+                if (args.getBoolean(1)) {
+                    jsWrapper = String.format("(function(){prompt(JSON.stringify([eval(%%s)]), 'gap-iab://%s')})()", callbackContext.getCallbackId());
+                }
+                injectDeferredObject(args.getString(0), jsWrapper);
             }
-            injectDeferredObject(args.getString(0), jsWrapper);
         }
         else if (action.equals("injectScriptFile")) {
             String jsWrapper;
@@ -404,6 +409,35 @@ public class InAppBrowser extends CordovaPlugin {
                     } else {
                         inAppWebView.evaluateJavascript(finalScriptToInject, null);
                     }
+                }
+            });
+        } else {
+            LOG.d(LOG_TAG, "Can't inject code into the system browser");
+        }
+    }
+
+    private void runJavascriptWithResult(String scriptToInject, CallbackContext callbackContext) {
+        if (inAppWebView!=null) {
+            final String finalScriptToInject = scriptToInject;
+            final CallbackContext finalCallbackContext = callbackContext;
+            final String callbackId = callbackContext.getCallbackId();
+
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @SuppressLint("NewApi")
+                @Override
+                public void run() {
+                    inAppWebView.evaluateJavascript(finalScriptToInject, new ValueCallback<String>() {
+                        @Override
+                        public void onReceiveValue(String s) {
+                            PluginResult pluginResult;
+                            try {
+                                pluginResult = new PluginResult(PluginResult.Status.OK, new JSONArray("[" + s + "]"));
+                            } catch(JSONException e) {
+                                pluginResult = new PluginResult(PluginResult.Status.JSON_EXCEPTION, e.getMessage());
+                            }
+                            finalCallbackContext.sendPluginResult(pluginResult);
+                        }
+                    });
                 }
             });
         } else {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -27,6 +27,9 @@ var isIos = cordova.platformId === 'ios';
 var isAndroid = cordova.platformId === 'android';
 var isBrowser = cordova.platformId === 'browser';
 
+var longStringLength = 10240 + 11;
+var longString = (new Array(longStringLength)).join('x');
+
 window.alert = window.alert || navigator.notification.alert;
 if (isWindows && navigator && navigator.notification && navigator.notification.alert) {
     // window.alert is defined but not functional on UWP
@@ -337,10 +340,10 @@ exports.defineManualTests = function (contentEl, createActionButton) {
                 var code = '(function(){\n' +
                   '    var header = document.getElementById("header");\n' +
                   '    header.innerHTML = "Script literal successfully injected";\n' +
-                  '    return "abc";\n' +
+                  '    return "' + longString + '";\n' +
                   '})()';
                 iab.executeScript({ code: code }, useCallback && function (results) {
-                    if (results && results.length === 1 && results[0] === 'abc') {
+                    if (results && results.length === 1 && results[0] === longString) {
                         alert('Results verified'); // eslint-disable-line no-undef
                     } else {
                         console.log(results);


### PR DESCRIPTION


### Platforms affected

Android

### What does this PR do?

Use `evaluateJavascript` to call javascript with callback for Android instead of Prompt
Fixes #303 seen with Chrome v69.0.3497.91 when callback response is greater than 10240 bytes

### What testing has been done on this change?

Added test case where callback has response length > 10240 bytes

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
