### PR TITLE
GH-417: Handle non-default target attribute values in WKWebView implementation on iOS

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -573,7 +573,14 @@ static CDVWKInAppBrowser* instance = nil;
     }
     
     if(shouldStart){
-        decisionHandler(WKNavigationActionPolicyAllow);
+        // Fix GH-417: Handle non-default target attribute
+        // Based on https://stackoverflow.com/a/25853806/777265
+        if (!navigationAction.targetFrame.isMainFrame){
+            [theWebView loadRequest:navigationAction.request];
+            decisionHandler(WKNavigationActionPolicyCancel);
+        }else{
+            decisionHandler(WKNavigationActionPolicyAllow);
+        }
     }else{
         decisionHandler(WKNavigationActionPolicyCancel);
     }


### PR DESCRIPTION
### Platforms affected
iOS (WKWebView)

### What does this PR do?
Handle non-default target attribute values (e.g. target=_blank) on links in WKWebView implementation on iOS. Fixes #417.

### What testing has been done on this change?
Added a test case link with target=_blank to [test container app](https://github.com/dpa99c/cordova-plugin-inappbrowser-test)