### PR TITLE
Fix beforeload for Android <= 7

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -263,7 +263,7 @@ public class InAppBrowser extends CordovaPlugin {
                 @SuppressLint("NewApi")
                 @Override
                 public void run() {
-                    if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.N_MR1) {
+                    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
                         currentClient.waitForBeforeload = false;
                         inAppWebView.setWebViewClient(currentClient);
                     } else {


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
On Android <= 7, using `beforeload` would crash the application due to change of Android API.
Fixes #386 



### Description
If device is running Android <= 7, 

### Testing
I ran it on Android 7 and 9, create `WebViewClient` instead of trying on relying on `WebView#getWebViewClient()` which is not available in these versions.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`) **Already made a commit without such prefix. Squashing it during merge should solve the issue.**
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
