### PR TITLE
[android] Prevent malformed callbackId from reaching app cordova view

### DIFF
--- a/src/android/InAppChromeClient.java
+++ b/src/android/InAppChromeClient.java
@@ -104,7 +104,7 @@ public class InAppChromeClient extends WebChromeClient {
             if(defaultValue.startsWith("gap-iab://")) {
                 PluginResult scriptResult;
                 String scriptCallbackId = defaultValue.substring(10);
-                if (scriptCallbackId.startsWith("InAppBrowser")) {
+                if (scriptCallbackId.matches("^InAppBrowser[0-9]{1,10}$")) {
                     if(message == null || message.length() == 0) {
                         scriptResult = new PluginResult(PluginResult.Status.OK, new JSONArray());
                     } else {
@@ -118,9 +118,14 @@ public class InAppChromeClient extends WebChromeClient {
                     result.confirm("");
                     return true;
                 }
+                else {
+                    // Anything else that doesn't look like InAppBrowser0123456789 should end up here
+                    LOG.w(LOG_TAG, "InAppBrowser callback called with invalid callbackId : "+ scriptCallbackId);
+                    result.cancel();
+                    return true;
+                }
             }
-            else
-            {
+            else {
                 // Anything else with a gap: prefix should get this message
                 LOG.w(LOG_TAG, "InAppBrowser does not support Cordova API calls: " + url + " " + defaultValue); 
                 result.cancel();


### PR DESCRIPTION

### Platforms affected
Android


### Motivation and Context
Certain poorly formed callbackId(s) could be used to execute js code in the context of the cordova app.



### Description
Uses a regex check to make sure the callbackId requested matches the pattern.  This is the same pattern matching code that is already used in iOS.



### Testing
Manually tested.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
