### PR TITLE
Fix test spec.5 to close inappbrowser after loadstop event

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -136,8 +136,10 @@ exports.defineAutoTests = function () {
                     verifyEvent(evt, 'exit');
                     done();
                 });
-                iabInstance.close();
-                iabInstance = null;
+                iabInstance.addEventListener('loadstop', function (evt) {
+                    iabInstance.close();
+                    iabInstance = null;
+                });
             });
 
             it('inappbrowser.spec.6 should support loaderror event', function (done) {


### PR DESCRIPTION
### Platforms affected
all platforms (but test only)


### Motivation and Context

The spec 'inappbrowser.spec.5 should support exit event' in `cordova-plugin-inappbrowser-tests.tests` is testing exit event.
But before this PR, `close` method may be fired before InAppBrowser opens a URL.
Then cordova-windows, the corresponding test (spec.6) sometimes fails, the InAppBrowser is kept opened. 
Then the next spec (spec.6) fails.
![2019-03-06 11 17 55](https://user-images.githubusercontent.com/5112183/53853014-49e1e300-4007-11e9-8a6e-35db2ed78aff.png)

This PR is to fix this issue.

### Description

Instead of calling `close()` method synchronously,
I call `close()` method in callback of `loadstop` event.


### Testing
With the help of cordova-mobile-spec, I confirmed all cordova-plugin-inappbrowser-tests.tests work well.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
