### PR TITLE
CB-9845cordova-plugin-inappbrowser destroy webview instance when close dialog

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -529,6 +529,7 @@ public class InAppBrowser extends CordovaPlugin {
                     public void onPageFinished(WebView view, String url) {
                         if (dialog != null) {
                             dialog.dismiss();
+                            childView.destroy();
                             dialog = null;
                         }
                     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
When dialog dismiss, webview does not be destroyed which will case the memory leak issue.
https://issues.apache.org/jira/browse/CB-9845?jql=text%20~%20%22close%20inappbrowser%22


### Description
Destroy webview when dismiss dialog



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ *] I've run the tests to see all new and existing tests pass
- [ *] I added automated test coverage as appropriate for this change
- [ *] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ *] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ *] I've updated the documentation if necessary
