### PR TITLE
feat(android): Add resize parameters for inappbroswer window

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -808,7 +808,7 @@ public class InAppBrowser extends CordovaPlugin {
                 WindowManager.LayoutParams wlp = window.getAttributes();
                 wlp.gravity = Gravity.TOP | Gravity.LEFT;
                 wlp.width = WindowManager.LayoutParams.MATCH_PARENT;
-                wlp.height = windowheight;
+                wlp.height = this.dpToPixels(windowheight);
                 wlp.dimAmount=0.5f; 
                 window.setFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL);
@@ -1084,9 +1084,9 @@ public class InAppBrowser extends CordovaPlugin {
                 WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
                 lp.copyFrom(dialog.getWindow().getAttributes());
                 lp.x = 0;
-                lp.y = appheaderheight;
+                lp.y = this.dpToPixels(appheaderheight);
                 lp.width = WindowManager.LayoutParams.MATCH_PARENT;
-                lp.height = windowheight;
+                lp.height = this.dpToPixels(windowheight);
 
                 dialog.setContentView(main);
                 dialog.show();

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -117,8 +117,10 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER = "footer";
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
+    private static final String APP_HEADER_HEIGHT = "appheaderheight";
+    private static final String WINDOW_HEIGHT = "windowheight";
 
-    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
+    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR, APP_HEADER_HEIGHT, WINDOW_HEIGHT);
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -149,6 +151,8 @@ public class InAppBrowser extends CordovaPlugin {
     private String beforeload = "";
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
+    private int appheaderheight;
+    private int windowheight;
 
     /**
      * Executes the request and returns PluginResult.
@@ -710,6 +714,12 @@ public class InAppBrowser extends CordovaPlugin {
             if (features.get(BEFORELOAD) != null) {
                 beforeload = features.get(BEFORELOAD);
             }
+            if (features.get(APP_HEADER_HEIGHT) != null) {
+                appheaderheight = Integer.valueOf(features.get(APP_HEADER_HEIGHT));
+            }
+            if (features.get(WINDOW_HEIGHT) != null) {
+                windowheight = Integer.valueOf(features.get(WINDOW_HEIGHT));
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -793,6 +803,17 @@ public class InAppBrowser extends CordovaPlugin {
                 dialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 dialog.setCancelable(true);
                 dialog.setInAppBroswer(getInAppBrowser());
+
+                Window window = dialog.getWindow();
+                WindowManager.LayoutParams wlp = window.getAttributes();
+                wlp.gravity = Gravity.TOP | Gravity.LEFT;
+                wlp.width = WindowManager.LayoutParams.MATCH_PARENT;
+                wlp.height = windowheight;
+                wlp.dimAmount=0.5f; 
+                window.setFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL);
+                window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+                window.setAttributes(wlp);
 
                 // Main container layout
                 LinearLayout main = new LinearLayout(cordova.getActivity());
@@ -1062,8 +1083,10 @@ public class InAppBrowser extends CordovaPlugin {
 
                 WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
                 lp.copyFrom(dialog.getWindow().getAttributes());
+                lp.x = 0;
+                lp.y = appheaderheight;
                 lp.width = WindowManager.LayoutParams.MATCH_PARENT;
-                lp.height = WindowManager.LayoutParams.MATCH_PARENT;
+                lp.height = windowheight;
 
                 dialog.setContentView(main);
                 dialog.show();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

- TO resize the window so we can access header and footer of base application.

<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->

TO add two parameters which can resize the window ( App-header-height  and height of inAppbroswer )

### Testing
<!-- Please describe in detail how you tested your changes. -->

iab = cordova.InAppBrowser.open(url,  '_self',
      'zoom=no,appheaderheight=50,windowheight=550')l

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
