### PR TITLE
ci(travis): add missing platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ matrix:
       <<: *_ios
     - env: PLATFORM=ios-12.0
       <<: *_ios
+    - env: PLATFORM=ios-12.2
+      <<: *_ios
 
     - env: PLATFORM=android-5.1
       <<: *_android


### PR DESCRIPTION
The Travis configuration is currently missing some platforms because there are issues:

https://github.com/apache/cordova-plugin-inappbrowser/issues/491

When those are fixed, this can be merged to improve the coverage of the CI.