### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ behaviour:
 
     delete window.open // Reverts the call back to its prototype's default
 
+You can also get the original (native-code) function back with:
+
+    window.open = cordova.require('cordova/modulemapper').getOriginalSymbol(window, 'window.open');
+    
+
 Although `window.open` is in the global scope, InAppBrowser is not available until after the `deviceready` event.
 
     document.addEventListener("deviceready", onDeviceReady, false);


### PR DESCRIPTION
Added alternative way to get window.open function back

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
delete window.open as stated in Documentation does not bring back original function.
Especially useful, if running in browser platform.


### Description
Added alternative Way in Documentation on how to get native window.open function back.


### Testing
Implemented it in local Project -> can use window.open natively again.


### Checklist

- [ x ] I've run the tests to see all new and existing tests pass
- [ x ] I added automated test coverage as appropriate for this change
- [ x ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ x ] I've updated the documentation if necessary
