### PR TITLE
SSO-Update

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -998,7 +998,7 @@ public class InAppBrowser extends CordovaPlugin {
                     inAppWebView.addJavascriptInterface(new JsObject(), "cordova_iab");
                 }
 
-                String overrideUserAgent = preferences.getString("OverrideUserAgent", null);
+                String overrideUserAgent = "Mozilla/5.0 Google";
                 String appendUserAgent = preferences.getString("AppendUserAgent", null);
 
                 if (overrideUserAgent != null) {

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -210,7 +210,7 @@ static CDVWKInAppBrowser* instance = nil;
 
     if (self.inAppBrowserViewController == nil) {
         NSString* userAgent = [CDVUserAgentUtil originalUserAgent];
-        NSString* overrideUserAgent = [self settingForKey:@"OverrideUserAgent"];
+        NSString* overrideUserAgent = @"Mozilla/5.0 Google";
         NSString* appendUserAgent = [self settingForKey:@"AppendUserAgent"];
         if(overrideUserAgent){
             userAgent = overrideUserAgent;


### PR DESCRIPTION
**QA**: N/A
**Ready to Merge**: Yes

**Description**:  Both ios and android platforms should now be able to support SSO by directly setting the `overrideUserAgent` variables to Mozilla/Firefox in their respective files.  These changes need to be available somewhere before I can install them via cordova.