### PR TITLE
Update InAppBrowser.java

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1379,17 +1379,7 @@ public class InAppBrowser extends CordovaPlugin {
         @Override
         public void onPageStarted(WebView view, String url, Bitmap favicon) {
             super.onPageStarted(view, url, favicon);
-            String newloc = "";
-            if (url.startsWith("http:") || url.startsWith("https:") || url.startsWith("file:")) {
-                newloc = url;
-            }
-            else
-            {
-                // Assume that everything is HTTP at this point, because if we don't specify,
-                // it really should be.  Complain loudly about this!!!
-                LOG.e(LOG_TAG, "Possible Uncaught/Unknown URI");
-                newloc = "http://" + url;
-            }
+            String newloc = url;
 
             // Update the UI if we haven't already
             if (!newloc.equals(edittext.getText().toString())) {


### PR DESCRIPTION
in line with allowing custom URI schemes and this issue I've changed the if statement that enforces http for no apparent reason: https://github.com/apache/cordova-plugin-inappbrowser/issues/548

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
IOS and Android, allows custom URI Schemes


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes issue here: https://github.com/apache/cordova-plugin-inappbrowser/issues/548
Allows the user to use window.open() to open custom URI's such as intents (tel:// or anotherapp://) easily.

### Description
<!-- Describe your changes in detail -->
All I did was remove an if statement that checks for the URI starting with Http, Https or File. so that the uri can be in any format.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested locally, working.


### Checklist

- [ x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change - no, tiny change
- [ x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ x] I've updated the documentation if necessary
