### PR TITLE
Allow user to override userAgent

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -105,8 +105,9 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HIDE_URL = "hideurlbar";
     private static final String FOOTER = "footer";
     private static final String FOOTER_COLOR = "footercolor";
+    private static final String OVERRIDE_USERAGENT = "OverrideUserAgent";
 
-    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
+    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR, OVERRIDE_USERAGENT);
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -890,7 +891,7 @@ public class InAppBrowser extends CordovaPlugin {
                     settings.setMediaPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture);
                 }
 
-                String overrideUserAgent = preferences.getString("OverrideUserAgent", null);
+                String overrideUserAgent = preferences.getString("OverrideUserAgent", features.get(OVERRIDE_USERAGENT));
                 String appendUserAgent = preferences.getString("AppendUserAgent", null);
 
                 if (overrideUserAgent != null) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
Allow user to override userAgent
Can use google-login, google login does not work with default Webview user-agent



### Description
Added a new option in `customizableOptions` and used this value in `overrideUserAgent` variable which was previously `null`


### Testing
Tested with the google-login flow in both android and iOS
Things work as usual if 'OverrideUserAgent` is not provided in the options


### Checklist

- [ x ] I've run the tests to see all new and existing tests pass
- [ x ] I added automated test coverage as appropriate for this change
- [ x ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ x ] I've updated the documentation if necessary
