### PR TITLE
[BREAKING] (all platforms): remove "window.open" overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ InAppBrowser window, by replacing window.open:
 
     window.open = cordova.InAppBrowser.open;
 
+If you change the browsers `window.open` function this way, it can have unintended side
+effects (especially if this plugin is included only as a dependency of another
+plugin).
+
 The InAppBrowser window behaves like a standard web browser,
 and can't access Cordova APIs. For this reason, the InAppBrowser is recommended
 if you need to load third-party (untrusted) content, instead of loading that
@@ -51,22 +55,6 @@ whitelist, nor is opening links in the system browser.
 
 The InAppBrowser provides by default its own GUI controls for the user (back,
 forward, done).
-
-For backwards compatibility, this plugin also hooks `window.open`.
-However, the plugin-installed hook of `window.open` can have unintended side
-effects (especially if this plugin is included only as a dependency of another
-plugin).  The hook of `window.open` will be removed in a future major release.
-Until the hook is removed from the plugin, apps can manually restore the default
-behaviour:
-
-    delete window.open // Reverts the call back to its prototype's default
-
-Although `window.open` is in the global scope, InAppBrowser is not available until after the `deviceready` event.
-
-    document.addEventListener("deviceready", onDeviceReady, false);
-    function onDeviceReady() {
-        console.log("window.open works well");
-    }
 
 ## Installation
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,6 @@
     <platform name="android">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
-            <clobbers target="window.open" />
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="InAppBrowser">
@@ -71,7 +70,6 @@
     <platform name="ios">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
-            <clobbers target="window.open" />
         </js-module>
         <config-file target="config.xml" parent="/*">
             <feature name="InAppBrowser">
@@ -108,7 +106,6 @@
     <platform name="osx">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
-            <clobbers target="window.open" />
         </js-module>
         <config-file target="config.xml" parent="/*">
             <feature name="InAppBrowser">
@@ -124,7 +121,6 @@
     <platform name="windows">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
-            <clobbers target="window.open" />
         </js-module>
         <js-module src="src/windows/InAppBrowserProxy.js" name="InAppBrowserProxy">
             <runs />
@@ -136,7 +132,6 @@
     <platform name="browser">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
-            <clobbers target="window.open" />
         </js-module>
         <js-module src="src/browser/InAppBrowserProxy.js" name="InAppBrowserProxy">
             <runs />


### PR DESCRIPTION
Closes #599

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All


### Motivation and Context
See #599 



### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested shortly with https://github.com/dpa99c/cordova-plugin-inappbrowser-test


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change -> **Some tests got stuck a first but restarting CI fixed that**
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
