### PR TITLE
Adding info about usesCleartextTraffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ instance, or the system browser.
 
 The default API level in the Cordova Android platform has been upgraded. On an Android 9 device, clear text communication is now disabled by default.
 
-To allow clear text communication again, set the android:usesCleartextTraffic on your application tag to true in `config.xml` file:
+To allow clear text communication again, set the `android:usesCleartextTraffic` on your application tag to true in `config.xml` file:
 `<platform name="android">
   <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
       <application android:usesCleartextTraffic="true" />

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ instance, or the system browser.
 
 The default API level in the Cordova Android platform has been upgraded. On an Android 9 device, clear text communication is now disabled by default.
 
-To allow clear text communication again, set the android:usesCleartextTraffic on your application tag to true:
+To allow clear text communication again, set the android:usesCleartextTraffic on your application tag to true in `config.xml` file:
 `<platform name="android">
   <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
       <application android:usesCleartextTraffic="true" />

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To allow clear text communication again, set the android:usesCleartextTraffic on
   </edit-config>
 </platform>`
 
-And also you need to add Android XML namespace `xmlns:android="http://schemas.android.com/apk/res/android"` to your widget tag in the same config.xml, like so:
+And also you need to add Android XML namespace `xmlns:android="http://schemas.android.com/apk/res/android"` to your widget tag in the same `config.xml`, like so:
 `<widget id="io.cordova.hellocordova" version="0.0.1" android-versionCode="13" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 </widget>`
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,21 @@ instance, or the system browser.
     var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
     var ref2 = cordova.InAppBrowser.open(encodeURI('http://ja.m.wikipedia.org/wiki/ハングル'), '_blank', 'location=yes');
 
+### Android Quirks
+
+The default API level in the Cordova Android platform has been upgraded. On an Android 9 device, clear text communication is now disabled by default.
+
+To allow clear text communication again, set the android:usesCleartextTraffic on your application tag to true:
+`<platform name="android">
+  <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+      <application android:usesCleartextTraffic="true" />
+  </edit-config>
+</platform>`
+
+And also you need to add Android XML namespace `xmlns:android="http://schemas.android.com/apk/res/android"` to your widget tag in the same config.xml, like so:
+`<widget id="io.cordova.hellocordova" version="0.0.1" android-versionCode="13" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+</widget>`
+
 ### OSX Quirks
 
 At the moment the only supported target in OSX is `_system`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "3.2.0",
+  "version": "3.2.1-dev",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="3.2.0">
+      version="3.2.1-dev">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "3.2.0",
+  "version": "3.2.1-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="3.2.0">
+    version="3.2.1-dev">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
The default API level in the Cordova Android platform has been upgraded. On an Android 9 device, clear text communication is now disabled by default.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After upgrading to Cordova Android 8.0, you will see the error: net::ERR_CLEARTEXT_NOT_PERMITTED errors when trying to connect to http:// targets on external websites


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
