### PR TITLE
Android GH-470 InAppBrowser: java.lang.IllegalArgumentException

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -313,7 +313,7 @@ public class InAppBrowser extends CordovaPlugin {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (dialog != null) {
+                    if (dialog != null && !cordova.getActivity().isFinishing()) {
                         dialog.show();
                     }
                 }
@@ -326,7 +326,7 @@ public class InAppBrowser extends CordovaPlugin {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (dialog != null) {
+                    if (dialog != null && !cordova.getActivity().isFinishing()) {
                         dialog.hide();
                     }
                 }
@@ -537,7 +537,7 @@ public class InAppBrowser extends CordovaPlugin {
                 childView.setWebViewClient(new WebViewClient() {
                     // NB: wait for about:blank before dismissing
                     public void onPageFinished(WebView view, String url) {
-                        if (dialog != null) {
+                        if (dialog != null && !cordova.getActivity().isFinishing()) {
                             dialog.dismiss();
                             dialog = null;
                         }


### PR DESCRIPTION
Fix interacting with views when Activity destroyed
Bug description https://stackoverflow.com/questions/22924825/view-not-attached-to-window-manager-crash

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #470 


### Description
<!-- Describe your changes in detail -->
Fix check is activity not destroyed before interacting with it

### Testing
<!-- Please describe in detail how you tested your changes. -->
As described in https://github.com/apache/cordova-plugin-inappbrowser/blob/master/CONTRIBUTING.md


### Checklist

- [ V] I've run the tests to see all new and existing tests pass
- [ X] I added automated test coverage as appropriate for this change
I can`t reproduce the problem. But this commit stop error messages in Firebase Crashlitics
- [V ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [V ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [V ] I've updated the documentation if necessary
(not necessary)
