### PR TITLE
(iOS) fixing problem status bar frame too narrow

### DIFF
--- a/src/ios/CDVInAppBrowserNavigationController.m
+++ b/src/ios/CDVInAppBrowserNavigationController.m
@@ -31,8 +31,17 @@
 
 - (void) viewDidLoad {
 
+    CGFloat topPadding = STATUSBAR_HEIGHT;
+    CGFloat bottomPadding = 0;
+    
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        topPadding = window.safeAreaInsets.top;
+        bottomPadding = window.safeAreaInsets.bottom;
+    }
+
     CGRect statusBarFrame = [self invertFrameIfNeeded:[UIApplication sharedApplication].statusBarFrame];
-    statusBarFrame.size.height = STATUSBAR_HEIGHT;
+    statusBarFrame.size.height = topPadding;
     // simplified from: http://stackoverflow.com/a/25669695/219684
 
     UIToolbar* bgToolbar = [[UIToolbar alloc] initWithFrame:statusBarFrame];


### PR DESCRIPTION
this approach considers the safe area insets

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change prevents from hardcoding the status bar frame size.
It doesn't really fix any open issue as far as I could see.


### Description
<!-- Describe your changes in detail -->
the status bar frame was too narrow so that some symbols of the iPhone XR statusbar weren't
contained by the frame fully.


### Testing
<!-- Please describe in detail how you tested your changes. -->
tested it in iPhone 8 and iPhone XR simulators


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
