### PR TITLE
feat(android): Ask for file permission when opening a download link (CB-12834) (rebased)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,10 +44,14 @@
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+        </config-file>
 
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
+        <source-file src="src/android/InAppBrowserDownloads.java" target-dir="src/org/apache/cordova/inappbrowser" />
 
         <!-- drawable src/android/resources -->
         <resource-file src="src/android/res/drawable-hdpi/ic_action_next_item.png" target="res/drawable-hdpi/ic_action_next_item.png" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,10 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>
+        <config-file target="res/values/strings.xml" parent="/resources">
+            <string name="inappbrowser_downloading_file">Downloading file \'%1$s\'</string>
+            <string name="inappbrowser_download_permission_error">Error downloading file, missing storage permissions</string>
+        </config-file>
 
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -121,6 +121,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
     private InAppBrowserDialog dialog;
+    private InAppBrowserDownloads downloads;
     private WebView inAppWebView;
     private EditText edittext;
     private CallbackContext callbackContext;
@@ -1079,10 +1080,26 @@ public class InAppBrowser extends CordovaPlugin {
                 if (openWindowHidden && dialog != null) {
                     dialog.hide();
                 }
+
+                if (InAppBrowser.this.downloads == null) {
+                    InAppBrowser.this.downloads = new InAppBrowserDownloads(InAppBrowser.this);
+                }
+
+                inAppWebView.setDownloadListener(
+                    InAppBrowser.this.downloads
+                );
             }
         };
         this.cordova.getActivity().runOnUiThread(runnable);
         return "";
+    }
+
+    public void onRequestPermissionResult(int requestCode, String[] permissions,
+         int[] grantResults) throws JSONException
+    {
+        if (InAppBrowser.this.downloads != null) {
+            InAppBrowser.this.downloads.onRequestPermissionResult(requestCode, permissions, grantResults);
+        }
     }
 
     /**

--- a/src/android/InAppBrowserDownloads.java
+++ b/src/android/InAppBrowserDownloads.java
@@ -1,0 +1,91 @@
+package org.apache.cordova.inappbrowser;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+
+import org.apache.cordova.CordovaWebView;
+import org.json.JSONException;
+
+//Download Files imports
+import android.app.DownloadManager;
+import android.os.Environment;
+import android.webkit.DownloadListener;
+import android.webkit.URLUtil;
+import android.widget.Toast;
+
+import static android.content.Context.DOWNLOAD_SERVICE;
+
+//Permissions
+import android.content.pm.PackageManager;
+
+public class InAppBrowserDownloads implements DownloadListener{
+
+    InAppBrowser plugin;
+
+    String url;
+    String userAgent;
+    String contentDisposition;
+    String mimetype;
+    long contentLength;
+
+    public InAppBrowserDownloads(InAppBrowser plugin) {
+        this.plugin = plugin;
+    }
+
+
+    public void onDownloadStart(String url, String userAgent,
+                                String contentDisposition, String mimetype,
+                                long contentLength) {
+
+        InAppBrowserDownloads.this.url = url;
+        InAppBrowserDownloads.this.userAgent = userAgent;
+        InAppBrowserDownloads.this.contentDisposition = contentDisposition;
+        InAppBrowserDownloads.this.mimetype = mimetype;
+        InAppBrowserDownloads.this.contentLength = contentLength;
+
+
+        if (Build.VERSION.SDK_INT >= 23) {
+            if (plugin.cordova.getActivity().checkSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+                processDownload();
+            } else {
+                plugin.cordova.requestPermission(InAppBrowserDownloads.this.plugin, 0, android.Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            }
+        } else { //permission is automatically granted on sdk<23 upon installation
+            processDownload();
+        }
+    }
+
+    public void onRequestPermissionResult(int requestCode, String[] permissions,
+         int[] grantResults) throws JSONException
+    {
+        for(int r:grantResults)
+        {
+            if(r == PackageManager.PERMISSION_DENIED)
+            {
+                Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Error downloading file, missing storage permissions", Toast.LENGTH_LONG).show();
+            } else {
+                InAppBrowserDownloads.this.processDownload();
+            }
+        }
+    }
+
+    protected void processDownload() {
+        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(InAppBrowserDownloads.this.url));
+        try {
+            request.allowScanningByMediaScanner();
+            request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED); //Notify client once download is completed!
+            final String filename = URLUtil.guessFileName(InAppBrowserDownloads.this.url, InAppBrowserDownloads.this.contentDisposition, InAppBrowserDownloads.this.mimetype);
+            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename);
+            DownloadManager dm = (DownloadManager) plugin.cordova.getActivity().getSystemService(DOWNLOAD_SERVICE);
+            dm.enqueue(request);
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT); //This is important!
+            intent.addCategory(Intent.CATEGORY_OPENABLE); //CATEGORY.OPENABLE
+            intent.setType("*/*");//any application,any extension
+            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Downloading File '" + filename + "'", Toast.LENGTH_LONG).show();
+        } catch (Exception exception) {
+            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Error downloading file, missing storage permissions", Toast.LENGTH_LONG).show();
+            exception.printStackTrace();
+        }
+    }
+}

--- a/src/android/InAppBrowserDownloads.java
+++ b/src/android/InAppBrowserDownloads.java
@@ -1,5 +1,6 @@
 package org.apache.cordova.inappbrowser;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
@@ -64,7 +65,7 @@ public class InAppBrowserDownloads implements DownloadListener{
         {
             if(r == PackageManager.PERMISSION_DENIED)
             {
-                Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Error downloading file, missing storage permissions", Toast.LENGTH_LONG).show();
+                Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), getStringResourceByName("inappbrowser_download_permission_error"), Toast.LENGTH_LONG).show();
             } else {
                 InAppBrowserDownloads.this.processDownload();
             }
@@ -94,10 +95,24 @@ public class InAppBrowserDownloads implements DownloadListener{
             intent.addCategory(Intent.CATEGORY_OPENABLE); //CATEGORY.OPENABLE
             intent.setType("*/*");//any application,any extension
 
-            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Downloading File '" + filename + "'", Toast.LENGTH_LONG).show();
+            String toastText = String.format(getStringResourceByName("inappbrowser_downloading_file"), filename);
+            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), toastText, Toast.LENGTH_LONG).show();
         } catch (Exception exception) {
-            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), "Error downloading file, missing storage permissions", Toast.LENGTH_LONG).show();
+            Toast.makeText(plugin.cordova.getActivity().getApplicationContext(), getStringResourceByName("inappbrowser_download_permission_error"), Toast.LENGTH_LONG).show();
             exception.printStackTrace();
         }
+    }
+
+    /**
+     * Grabs a string from the activity's resources.
+     *
+     * @param aString The name of the resource to retrieve
+     * @return        The string contents of the resource
+     */
+    private String getStringResourceByName(String aString) {
+        Activity activity = plugin.cordova.getActivity();
+        String packageName = activity.getPackageName();
+        int resId = activity.getResources().getIdentifier(aString, "string", packageName);
+        return activity.getString(resId);
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See #201 and #244.

### Description
<!-- Describe your changes in detail -->

I wanted to bring back attention to apache/cordova-plugin-inappbrowser#244, but noticed that the original PR contains some merge conflicts and is quite behind the master branch. I also noticed that there are a lot of formatting changes in that PR that are not quite related to the added feature, so thought that maybe creating a new PR without the formatting changes will make it easier to review and merge.

This PR also contains the cookies passing improvement by @RafaelKR.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Tested in the app where I needed to have this feature.
  - It asks for the file storage permissions when you try to download a file for the first time.
  - If the permissions were given, it shows a toast with a message that the file download started. You can observe the download progress through notification drawer and you can also cancel the download from there.
  - If the permissions were not given, it shows a toast with an error message.

- Followed the testing instructions from CONTRIBUTING.md
  - Auto Tests completed successfully.
  - There were some issues with Manual Tests on my device, but it seems that same issues also happen when compiling from upstream master branch.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
