### PR TITLE
[GH-652] add check for openInSystem postNotification

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -357,8 +357,10 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
-    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
-    [[UIApplication sharedApplication] openURL:url];
+    if ([[UIApplication sharedApplication] openURL:url] == NO) {
+        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+        [[UIApplication sharedApplication] openURL:url];
+    }
 }
 
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
fixes #652 

This fix prevents window.handleOpenURL from being triggered by calls to _system browser through InAppBrowser which was previously fixed in UIWebView version of IAB but still exists in WKWebView version

### Description
Add ` if ([[UIApplication sharedApplication] openURL:url] == NO)` check in openInSystem method which was present in UIWebView version of IAB but not WKWebView.

### Testing
Ran plugintests repo
Manually tested in my own project where I first noticed the issue
Manually tested in minimum reproduction repo and pushed [to a branch](https://github.com/j--w/iab-handleopenurl-bug/commit/e910b312cb606eee2d3c922c70bf696117cfa2f3)

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
