### PR TITLE
(ios & android) Reduce IAB Web View height from the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ instance, or the system browser.
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).
     - __shouldPauseOnSuspend__: Set to `yes` to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues like described in [CB-11013](https://issues.apache.org/jira/browse/CB-11013)).
     - __useWideViewPort__: Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is `no`, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is `yes` and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to `yes`).
-    - __fullscreen__: Sets whether the InappBrowser WebView is displayed fullscreen or not. In fullscreen mode, the status bar is hidden. Default value is `yes`.
+    - __fullscreen__: Sets whether the InAppBrowser WebView is displayed fullscreen or not. In fullscreen mode, the status bar is hidden. Default value is `yes`.
+    - __bottomreduceheightby__: Reduces the IAB WebView height by the amount of pixels specified and moves the the IAB WebView to the top of the screen. That results in the content of the underlying Cordova window to be (partially) shown. Default value is `0`.
 
     iOS supports these additional options:
 
@@ -153,6 +154,7 @@ instance, or the system browser.
     - __transitionstyle__: Set to `fliphorizontal`, `crossdissolve` or `coververtical` to set the [transition style](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalTransitionStyle) (defaults to `coververtical`).
     - __toolbarposition__: Set to `top` or `bottom` (default is `bottom`). Causes the toolbar to be at the top or bottom of the window.
     - __hidespinner__: Set to `yes` or `no` to change the visibility of the loading indicator (defaults to `no`).
+    - __bottomreduceheightby__: Reduces the IAB WebView height by the amount of pixels specified and moves the the IAB WebView to the top of the screen. That results in the content of the underlying Cordova window to be (partially) shown. Default value is `0`.
 
     Windows supports these additional options:
 

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -43,6 +43,7 @@
 @property (nonatomic, assign) BOOL allowinlinemediaplayback;
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL disallowoverscroll;
+@property (nonatomic, copy) NSNumber* bottomreduceheightby;
 @property (nonatomic, copy) NSString* beforeload;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -44,6 +44,7 @@
         self.lefttoright = false;
         self.toolbarcolor = nil;
         self.toolbartranslucent = YES;
+        self.bottomreduceheightby = [NSNumber numberWithFloat:0.0];
         self.beforeload = @"";
     }
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -43,6 +43,7 @@
 
 @interface CDVWKInAppBrowser () {
     NSInteger _previousStatusBarStyle;
+    CDVInAppBrowserOptions* _browserOptions;
 }
 @end
 
@@ -61,6 +62,7 @@ static CDVWKInAppBrowser* instance = nil;
     _callbackIdPattern = nil;
     _beforeload = @"";
     _waitForBeforeload = NO;
+    _browserOptions = nil;
 }
 
 - (void)onReset
@@ -125,7 +127,8 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInInAppBrowser:(NSURL*)url withOptions:(NSString*)options
 {
-    CDVInAppBrowserOptions* browserOptions = [CDVInAppBrowserOptions parseOptions:options];
+    _browserOptions = [CDVInAppBrowserOptions parseOptions:options];
+    CDVInAppBrowserOptions* browserOptions = _browserOptions;
     
     WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
     if (browserOptions.cleardata) {
@@ -303,6 +306,10 @@ static CDVWKInAppBrowser* instance = nil;
                 CGRect frame = [[UIScreen mainScreen] bounds];
                 if(initHidden && osVersion < 11){
                    frame.origin.x = -10000;
+                }
+                if(nil != _browserOptions) {
+                    // Resize the window if it has to be reduced to less than the available screen height
+                    frame.size.height = frame.size.height - [_browserOptions.bottomreduceheightby floatValue];
                 }
                 strongSelf->tmpWindow = [[UIWindow alloc] initWithFrame:frame];
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS & Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This change is needed in situations where the main app has some content on the bottom of the screen that should be visible even when the IAB web view is shown.
For instance, clickable footer, ad content, etc.

<!-- If it fixes an open issue, please link to the issue here. -->
This change addresses a similar issue to feature request #409, which is limited to Android only. This solution also includes iOS.


### Description
<!-- Describe your changes in detail -->
This change adds a new setting in both Android and iOS named: **bottomreduceheightby** which takes an integer as value. It defaults to 0 to maintain backward compatibility.
When a value different than 0 is specified, the IAB web view height is reduced by that amount of pixels and aligned to the top of the screen. That results in a portion of the underlying Cordova window to be shown (as much as the value assigned to the setting) so that its content is fully visible and accessible.

NOTE: if needed, a similar option can be added for the top of the IAB web view.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Testing was done manually as I am not sure on how to automate it.

1. Created a new Cordova test app using cordova-plugin-inappbrowser.

2. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "");`
    and verified the web view is occupying the entire screen (default behavior).

3. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "bottomreduceheightby=0");`
     and verified the web view is occupying the entire screen (default behavior).

4. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "bottomreduceheightby=60");`
    and verified the web view is occupying the entire screen minus 60 pixels at the bottom.
    Also, verified the possibility to interact with the content in the underlying Cordova window.

We repeated the above tests with both Android and iOS.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
