### PR TITLE
(ios) Remove fake status bar with hardcoded height to fix issues in iOS devices with a notch

### DIFF
--- a/src/ios/CDVInAppBrowserNavigationController.m
+++ b/src/ios/CDVInAppBrowserNavigationController.m
@@ -19,8 +19,6 @@
 
 #import "CDVInAppBrowserNavigationController.h"
 
-#define    STATUSBAR_HEIGHT 20.0
-
 @implementation CDVInAppBrowserNavigationController : UINavigationController
 
 - (void) dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
@@ -30,12 +28,7 @@
 }
 
 - (void) viewDidLoad {
-
-    CGRect statusBarFrame = [self invertFrameIfNeeded:[UIApplication sharedApplication].statusBarFrame];
-    statusBarFrame.size.height = STATUSBAR_HEIGHT;
-    // simplified from: http://stackoverflow.com/a/25669695/219684
-
-    UIToolbar* bgToolbar = [[UIToolbar alloc] initWithFrame:statusBarFrame];
+    UIToolbar* bgToolbar = [[UIToolbar alloc] init];
     bgToolbar.barStyle = UIBarStyleDefault;
     [bgToolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
     [self.view addSubview:bgToolbar];

--- a/src/ios/CDVInAppBrowserNavigationController.m
+++ b/src/ios/CDVInAppBrowserNavigationController.m
@@ -28,11 +28,6 @@
 }
 
 - (void) viewDidLoad {
-    UIToolbar* bgToolbar = [[UIToolbar alloc] init];
-    bgToolbar.barStyle = UIBarStyleDefault;
-    [bgToolbar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
-    [self.view addSubview:bgToolbar];
-
     [super viewDidLoad];
 }
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -35,7 +35,6 @@
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
 #define    TOOLBAR_HEIGHT 44.0
-#define    STATUSBAR_HEIGHT 20.0
 #define    LOCATIONBAR_HEIGHT 21.0
 #define    FOOTER_HEIGHT ((TOOLBAR_HEIGHT) + (LOCATIONBAR_HEIGHT))
 
@@ -892,7 +891,7 @@ BOOL isExiting = FALSE;
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
     
-    self.view.backgroundColor = [UIColor grayColor];
+    self.view.backgroundColor = [UIColor clearColor];
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];
@@ -1098,8 +1097,10 @@ BOOL isExiting = FALSE;
     if (IsAtLeastiOSVersion(@"7.0") && !viewRenderedAtLeastOnce) {
         viewRenderedAtLeastOnce = TRUE;
         CGRect viewBounds = [self.webView bounds];
-        viewBounds.origin.y = STATUSBAR_HEIGHT;
-        viewBounds.size.height = viewBounds.size.height - STATUSBAR_HEIGHT;
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+        CGFloat statusBarHeight = statusBarFrame.size.height;
+        viewBounds.origin.y = statusBarHeight;
+        viewBounds.size.height = viewBounds.size.height - statusBarHeight;
         self.webView.frame = viewBounds;
         [[UIApplication sharedApplication] setStatusBarStyle:[self preferredStatusBarStyle]];
     }
@@ -1120,8 +1121,10 @@ BOOL isExiting = FALSE;
 }
 
 - (void) rePositionViews {
-    if ([_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop]) {
-        [self.webView setFrame:CGRectMake(self.webView.frame.origin.x, TOOLBAR_HEIGHT, self.webView.frame.size.width, self.webView.frame.size.height)];
+    if ((_browserOptions.toolbar) && ([_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop])) {
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+        CGFloat statusBarHeight = statusBarFrame.size.height;
+        [self.webView setFrame:CGRectMake(self.webView.frame.origin.x, TOOLBAR_HEIGHT + [self getStatusBarOffset], self.webView.frame.size.width, self.webView.frame.size.height - [self getStatusBarOffset] + statusBarHeight)];
         [self.toolbar setFrame:CGRectMake(self.toolbar.frame.origin.x, [self getStatusBarOffset], self.toolbar.frame.size.width, self.toolbar.frame.size.height)];
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
IAB adds what has been referred as a "fake status bar" that creates issues on devices with a notch, such as iPhone X/XS/XM, etc.
In order to fix such issues, the fake status bar has to be removed.
 
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes: #604, #638, #301

Related to: #546, #265


### Description
<!-- Describe your changes in detail -->
The fake status bar is removed from the IAB window and both height and the position of the IAB window is modified to account for the (real) iOS status bar. That is needed to correctly display the content of the iOS status bar without overlapping the content in the IAB window in portrait mode.
The color of the iOS status bar is set to transparent to match the background color of the underlying Cordova app.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Testing was done manually as I am not sure on how to automate it.

1. Created a new Cordova test app using cordova-plugin-inappbrowser.

2. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "");`
    and verified that the iOS status bar is shown around the notch and the web view is displayed just below the iOS status bar (default behavior for iOS apps). The status bar color matches the background color of the underlying Cordova app.

3. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "toolbar=yes,toolbarposition=top");`
     and verified that the iOS status bar is shown around the notch, the toolbar is displayed just below the iOS status bar and the web view is displayed just below the toolbar (default behavior for iOS apps). The status bar color matches the background color of the underlying Cordova app.

4. Executed:
    `cordova.InAppBrowser.open(url, "_blank", "toolbar=yes,toolbarposition=top");`
     on a device without notch and verified that the iOS status bar is shown on the top of the screen, the toolbar is displayed just below the iOS status bar and the web view is displayed just below the toolbar (default behavior for iOS apps). The status bar color matches the background color of the underlying Cordova app.

The tests above were executed for both portrait and landscape orientation. Note that in landscape mode, no status bar is displayed, which is the default iOS behavior for that mode with any app.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
