### PR TITLE
Allow App using inappbrowser to be hosted in a cross-origin iframe

### DIFF
--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -20,12 +20,6 @@
 */
 
 (function () {
-    // special patch to correctly work on Ripple emulator (CB-9760)
-    if (window.parent && !!window.parent.ripple) { // https://gist.github.com/triceam/4658021
-        module.exports = window.open.bind(window); // fallback to default window.open behaviour
-        return;
-    }
-
     var exec = require('cordova/exec');
     var channel = require('cordova/channel');
     var modulemapper = require('cordova/modulemapper');


### PR DESCRIPTION
### Platforms affected

Browsers such as Firefox, Chrome

### Motivation and Context

Allow App using inappbrowser to be hosted in a cross-origin iframe

closes GH-419

### Description

Prevent an uncaught exception.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
