### PR TITLE
fix(ios): Allow loading local html files

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1083,8 +1083,12 @@ BOOL isExiting = FALSE;
 
 - (void)navigateTo:(NSURL*)url
 {
-    NSURLRequest* request = [NSURLRequest requestWithURL:url];
-    [self.webView loadRequest:request];
+    if ([url.scheme isEqualToString:@"file"]) {
+        [self.webView loadFileURL:url allowingReadAccessToURL:url];
+    } else {
+        NSURLRequest* request = [NSURLRequest requestWithURL:url];
+        [self.webView loadRequest:request];
+    }
 }
 
 - (void)goBack:(id)sender


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

Opening a local HTML file with InAppBrowser and UIWebView works fine, but the same code with WKWebView throws an error:

> webView:didFailProvisionalNavigation - 1: The operation couldn’t be completed. (kCFErrorDomainCFNetwork error 1.)

This Pull request is meant to fix that. I'm not an iOS developer, so I'm not sure if the _allowingReadAccessToURL_ param should be more flexible or even configurable by options, but the change seemed to work in my case.

I tried opening an issue in the tracker, but I couldn't select the Apache Cordova project when creating the issue, I guess I lack some permissions.

### Description

I read that in WKWebView the function to load files is _loadFileURL_ instead of _loadRequest_, so I'm using that function if the URL scheme is "file".


### Testing

I've executed "npm run tests" and no error was displayed (no success message either, so I'm not 100% sure it worked).

I've tested this in our project but with the 3.2.0 version instead of master branch, so this should have a more intensive testing.


### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
