### PR TITLE
ci(ios): remove wkwebview plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
-    - env: PLATFORM=local/ios-13.6
+    - env: PLATFORM=local/ios-12.2
       <<: *_ios
 
     # many tests with saucelabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
-    - env: PLATFORM=local/ios-10.0
+    - env: PLATFORM=local/ios-13.0
       <<: *_ios
 
     # many tests with saucelabs
@@ -81,7 +81,7 @@ before_install:
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
   # install paramedic if not running on paramedic repo
-  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi
+  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic#ios13; fi
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_install:
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
   # install paramedic if not running on paramedic repo
-  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic#ios13-test; fi
+  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_install:
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
   # install paramedic if not running on paramedic repo
-  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic#ios13; fi
+  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic#ios13-test; fi
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
-    - env: PLATFORM=local/ios-13.0
+    - env: PLATFORM=local/ios-13.6
       <<: *_ios
 
     # many tests with saucelabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
-    - env: PLATFORM=local/ios-12.2
+    - env: PLATFORM=local/ios-10.0
       <<: *_ios
 
     # many tests with saucelabs

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -30,8 +30,6 @@
     </js-module>
 
     <platform name="ios">
-      <!-- The WKWebView implementation for inappbrowser requires the presence of this plugin  -->
-      <dependency id="cordova-plugin-wkwebview-engine" />
       <dependency id="cordova-plugin-wkwebview-engine-allowfileaccess" url="https://github.com/knight9999/cordova-plugin-wkwebview-engine-allowfileaccess.git" />
     </platform>
 

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -29,10 +29,5 @@
     <js-module src="tests.js" name="tests">
     </js-module>
 
-    <platform name="ios">
-      <dependency id="cordova-plugin-wkwebview-engine-allowfileaccess" url="https://github.com/knight9999/cordova-plugin-wkwebview-engine-allowfileaccess.git" />
-    </platform>
-
-
     <asset src="resources" target="cdvtests/iab-resources" />
 </plugin>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See build issues in #688 

### Description
<!-- Describe your changes in detail -->
Since we are now testing against Cordova iOS 6.x we no longer need the WKWebView plugin in the test project. In fact this fixes the build again on Travis aside from Browser which is broken in all plugins for different reasons.

### Testing
<!-- Please describe in detail how you tested your changes. -->
CI


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
