### PR TITLE
fix(ios):  Allow loading of external local files from the same directory as loaded local html

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1088,7 +1088,8 @@ BOOL isExiting = FALSE;
 - (void)navigateTo:(NSURL*)url
 {
     if ([url.scheme isEqualToString:@"file"]) {
-        [self.webView loadFileURL:url allowingReadAccessToURL:url];
+        NSURL* directoryURL = [url URLByDeletingLastPathComponent];
+        [self.webView loadFileURL:url allowingReadAccessToURL:directoryURL];
     } else {
         NSURLRequest* request = [NSURLRequest requestWithURL:url];
         [self.webView loadRequest:request];


### PR DESCRIPTION
# Platforms affected

iOS

### Motivation and Context

Many applications rely on ability to display local resources using inappbrowser. 
WKWebView implementation introduced additional security which needs to be handled.


Fixes #657 
Improves on #883 

### Description
Pull request #693 made loading of local html files is possible in v4 WKWebView branch. However - how it was implemented only enabled opening of a single html file in IAB without its external resources (eg. css/images/javascript) throwing `didStartProvisionalNavigation` (not allowed).

As per [Apple documentation](https://developer.apple.com/documentation/webkit/wkwebview/1414973-loadfileurl) `loadFileURL` accepts 2 parameters:
- `URL` - The file URL to navigate to.
- `readAccessURL` -The URL to allow read access to.

If readAccessURL references a single file, only that file may be loaded by WebKit. 
**If readAccessURL references a directory, files inside that file may be loaded by WebKit.**

Now, I extract directory from passed url and pass it to the  `loadFileURL` method making **external local content from the same directory as loaded html** - loadable.

### Testing

npm test pass. multiple builds on multiple real devices with and without notch.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
