### PR TITLE
GH-480 (android): Add option to open system's browser in a new task

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ instance, or the system browser.
     - __shouldPauseOnSuspend__: Set to `yes` to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues like described in [CB-11013](https://issues.apache.org/jira/browse/CB-11013)).
     - __useWideViewPort__: Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is `no`, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is `yes` and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to `yes`).
     - __fullscreen__: Sets whether the InappBrowser WebView is displayed fullscreen or not. In fullscreen mode, the status bar is hidden. Default value is `yes`.
+    - __launchInNewTask__: When using target `_system`, sets to `yes` to launch system's browser in a new task. Default value is `no`.
 
     iOS supports these additional options:
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -120,6 +120,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
+    private static final String LAUNCH_NEW_TASK = "launchInNewTask";
 
     private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
@@ -151,6 +152,7 @@ public class InAppBrowser extends CordovaPlugin {
     private String footerColor = "";
     private String beforeload = "";
     private boolean fullscreen = true;
+    private boolean launchInNewTask = false;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
 
@@ -243,7 +245,7 @@ public class InAppBrowser extends CordovaPlugin {
                     // SYSTEM
                     else if (SYSTEM.equals(target)) {
                         LOG.d(LOG_TAG, "in system");
-                        result = openExternal(url);
+                        result = openExternal(url, features);
                     }
                     // BLANK - or anything else
                     else {
@@ -461,7 +463,7 @@ public class InAppBrowser extends CordovaPlugin {
      * @param url the url to load.
      * @return "" if ok, or error message.
      */
-    public String openExternal(String url) {
+    public String openExternal(String url, HashMap<String, String> features) {
         try {
             Intent intent = null;
             intent = new Intent(Intent.ACTION_VIEW);
@@ -474,6 +476,17 @@ public class InAppBrowser extends CordovaPlugin {
                 intent.setData(uri);
             }
             intent.putExtra(Browser.EXTRA_APPLICATION_ID, cordova.getActivity().getPackageName());
+
+            if (features != null) {
+                String launchNewTask = features.get(LAUNCH_NEW_TASK);
+                if (launchNewTask != null) {
+                    launchInNewTask = launchNewTask.equals("yes") ? true : false;
+                }
+            }
+
+            if (launchInNewTask) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            }
             // CB-10795: Avoid circular loops by preventing it from opening in the current app
             this.openExternalExcludeCurrentApp(intent);
             return "";


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
When opening external app with inAppBrowser using target: `_system`, sometimes we lose the ability to go back to the initial app, as described in #480 

Closes #480 
Closes #735 


### Description
This PR add an option `launchInNewTask` which, when used with target: `_system` on android, add the flag `Intent.FLAG_ACTIVITY_NEW_TASK` to the Intent used to launch system's browser.


### Testing
I have an (proprietary) ionic/cordova app where I encountered this issue when opening `geo:` url with InAppBrowser.
I checked that the issue is still here when I don't add the new option `launchInNewTask`, and that this issue is gone when I add `launchInNewTask=yes` to the options.

I didn't add any new automated tests - not sure how.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
