### PR TITLE
Updated typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,12 @@
 // TypeScript Version: 2.3
 type channel = "loadstart" | "loadstop" | "loaderror" | "exit" | "message" | "customscheme";
 
-interface Window {
+/**
+ * The object returned from a call to window.open.
+ * NOTE: The InAppBrowser window behaves like a standard web browser, and can't access Cordova APIs.
+ */
+interface InAppBrowser {
+
     /**
      * Opens a URL in a new InAppBrowser instance, the current browser instance, or the system browser.
      * @param  url     The URL to load.
@@ -18,13 +23,7 @@ interface Window {
      *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
      */
     open(url: string, target?: string, options?: string): InAppBrowser;
-}
 
-/**
- * The object returned from a call to window.open.
- * NOTE: The InAppBrowser window behaves like a standard web browser, and can't access Cordova APIs.
- */
-interface InAppBrowser extends Window {
     onloadstart(type: Event): void;
     onloadstop(type: InAppBrowserEvent): void;
     onloaderror(type: InAppBrowserEvent): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@
 type channel = "loadstart" | "loadstop" | "loaderror" | "exit" | "message" | "customscheme";
 
 /**
- * The object returned from a call to window.open.
+ * The object returned from a call to cordova.InAppBrowser.open.
  * NOTE: The InAppBrowser window behaves like a standard web browser, and can't access Cordova APIs.
  */
 interface InAppBrowser {


### PR DESCRIPTION
Updated the typings to reflect the latest version of the plugin
Closes #811 

### Platforms affected
n/a (js only)


### Motivation and Context
typings do not compile correctly.
inappbrowser nolonger overrides window.open behaviour



### Description
updated typings



### Testing
used my updated typings file in my project.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
