### PR TITLE
chore: bump engines requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       },
       "5.0.0": {
         "cordova-android": ">=9.0.0",
-        "cordova-ios": ">=5.1.0",
+        "cordova-ios": ">=6.0.0",
         "cordova": ">=9.0.0"
       },
       "6.0.0": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
         "cordova-ios": ">=4.0.0"
       },
       "5.0.0": {
+        "cordova-android": ">=9.0.0",
+        "cordova-ios": ">=5.1.0",
+        "cordova": ">=9.0.0"
+      },
+      "6.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,7 @@
     <engines>
         <engine name="cordova" version=">=9.0.0"/>
         <engine name="cordova-android" version=">=9.0.0" />
-        <engine name="cordova-ios" version=">=5.1.0" />
+        <engine name="cordova-ios" version=">=6.0.0" />
     </engines>
 
     <!-- android -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,8 +30,9 @@
     <issue>https://github.com/apache/cordova-plugin-inappbrowser/issues</issue>
 
     <engines>
-      <engine name="cordova" version=">=3.1.0" /><!-- Needs cordova/urlutil -->
-      <engine name="cordova-ios" version=">=4.0.0" />
+        <engine name="cordova" version=">=9.0.0"/>
+        <engine name="cordova-android" version=">=9.0.0" />
+        <engine name="cordova-ios" version=">=5.1.0" />
     </engines>
 
     <!-- android -->


### PR DESCRIPTION
require newer cordova-ios, cordova-android and cordova versions