### PR TITLE
feat(ios): add InAppBrowserStatusBarStyle 'darkcontent' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ simply hook `window.open` during initialization.  For example:
 ### Preferences
 
 #### <b>config.xml</b>
-- <b>InAppBrowserStatusBarStyle [iOS only]</b>: (string, options 'lightcontent', 'darkcontent' or 'default'. Defaults to 'default') set text color style for iOS.
+- <b>InAppBrowserStatusBarStyle [iOS only]</b>: (string, options 'lightcontent', 'darkcontent' or 'default'. Defaults to 'default') set text color style for iOS. 'lightcontent' is intended for use on dark backgrounds. 'darkcontent' is only available since iOS 13 and intended for use on light backgrounds.
 ```
 <preference name="InAppBrowserStatusBarStyle" value="lightcontent" />
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ simply hook `window.open` during initialization.  For example:
 ### Preferences
 
 #### <b>config.xml</b>
-- <b>InAppBrowserStatusBarStyle [iOS only]</b>: (string, options 'lightcontent' or 'default'. Defaults to 'default') set text color style for iOS.
+- <b>InAppBrowserStatusBarStyle [iOS only]</b>: (string, options 'lightcontent', 'darkcontent' or 'default'. Defaults to 'default') set text color style for iOS.
 ```
 <preference name="InAppBrowserStatusBarStyle" value="lightcontent" />
 ```

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1067,6 +1067,12 @@ BOOL isExiting = FALSE;
     NSString* statusBarStylePreference = [self settingForKey:@"InAppBrowserStatusBarStyle"];
     if (statusBarStylePreference && [statusBarStylePreference isEqualToString:@"lightcontent"]) {
         return UIStatusBarStyleLightContent;
+    } else if (statusBarStylePreference && [statusBarStylePreference isEqualToString:@"darkcontent"]) {
+        if (@available(iOS 13.0, *)) {
+            return  UIStatusBarStyleDarkContent;
+        } else {
+            return UIStatusBarStyleDefault;
+        }
     } else {
         return UIStatusBarStyleDefault;
     }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1069,7 +1069,7 @@ BOOL isExiting = FALSE;
         return UIStatusBarStyleLightContent;
     } else if (statusBarStylePreference && [statusBarStylePreference isEqualToString:@"darkcontent"]) {
         if (@available(iOS 13.0, *)) {
-            return  UIStatusBarStyleDarkContent;
+            return UIStatusBarStyleDarkContent;
         } else {
             return UIStatusBarStyleDefault;
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If the IAB loads a page with a white background on a device with dark mode enabled the statusbar will be white with white content. This PR ads the config.xml to set statusbar content to dark to make it readable again for pages like this.


### Description
<!-- Describe your changes in detail -->
https://github.com/apache/cordova-plugin-inappbrowser/pull/765 added the option to set the statusbar to light content. iOS 13 introduced a new dark content option and this PR adds that.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual test
No automatic tests

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
