### PR TITLE
fix(android): add space between default useragent and custom AppendUserAgent

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -970,7 +970,7 @@ public class InAppBrowser extends CordovaPlugin {
                     settings.setUserAgentString(overrideUserAgent);
                 }
                 if (appendUserAgent != null) {
-                    settings.setUserAgentString(settings.getUserAgentString() + appendUserAgent);
+                    settings.setUserAgentString(settings.getUserAgentString() + " " + appendUserAgent);
                 }
 
                 //Toggle whether this is enabled or not!


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

cordova-android adds a space between the default user agent and the custom one
(https://github.com/apache/cordova-android/blob/c144c0811249e22f91253ef919cc767f892a8fdf/framework/src/org/apache/cordova/engine/SystemWebViewEngine.java#L214) and the InAppBrowser does not. If a user/applications expect them to be equal this could cause an error.



### Description
<!-- Describe your changes in detail -->
With this change cordova-androids and the IAB user agent are exactly the same.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing, no tests  for useragent found


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
