### PR TITLE
RMET-331:  fix setting closeButtonCaption to empty

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -686,6 +686,8 @@ public class InAppBrowser extends CordovaPlugin {
             String closeButtonCaptionSet = features.get(CLOSE_BUTTON_CAPTION);
             if (closeButtonCaptionSet != null) {
                 closeButtonCaption = closeButtonCaptionSet;
+            } else {
+                closeButtonCaption = "";
             }
             String closeButtonColorSet = features.get(CLOSE_BUTTON_COLOR);
             if (closeButtonColorSet != null) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Change fixes following issue on Android:
https://outsystemsrd.atlassian.net/browse/RMET-331

Tried to fix plugin logic in ousystem studio but could not and this is the easiest fix I found.


### Description
<!-- Describe your changes in detail -->
Unlike iOS - option values are not reset to default one. And if previously value was set to non-empty string you can't reset value back to Empty ("X"close button on Android and "Done" on iOS). So we just add else case where we set value to empty string.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Changes were tested on Android emulator using debug mode.

### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
