### PR TITLE
(android) Fix for webView window not being destroyed correctly causing memory leak (#290)

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -534,6 +534,16 @@ public class InAppBrowser extends CordovaPlugin {
                             dialog.dismiss();
                             dialog = null;
                         }
+                        
+                        // Fix for webView window not being destroyed correctly causing memory leak
+                        // (https://github.com/apache/cordova-plugin-inappbrowser/issues/290)
+                        if (url.equals(new String("about:blank"))) {
+                            inAppWebView.onPause();
+                            inAppWebView.removeAllViews();
+                            inAppWebView.destroyDrawingCache();
+                            inAppWebView.destroy();
+                            inAppWebView = null;
+                        }
                     }
                 });
                 // NB: From SDK 19: "If you call methods on WebView from any thread


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes #290 


### Description
<!-- Describe your changes in detail -->
A fix for the issue reported in #290 is suggested in the same. I created this pull request after implementing the fix in my own forked repo and verifying it works as intended in Android.


### Testing
<!-- Please describe in detail how you tested your changes. -->
- Launched the app compiled without the fix on Android and verified the issue is present using the Chrome Inspector (window with about:blank is present after IAB window is closed)
- Compiled the app with the fix and launched it
- Opened an IAB window
- Closed the IAB window and verified the issue is no longer present using the Chrome Inspector (window with about:blank is no longer present after IAB window is closed)
- Repeated the test a few time


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
