### PR TITLE
fix(android): Allow loading local files

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -945,6 +945,13 @@ public class InAppBrowser extends CordovaPlugin {
                 settings.setBuiltInZoomControls(showZoomControls);
                 settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
 
+                if (preferences.getBoolean("AndroidInsecureFileModeEnabled", false)) {
+                    LOG.d(LOG_TAG, "Enabled insecure file access");
+
+                    settings.setAllowFileAccess(true);
+                    settings.setAllowUniversalAccessFromFileURLs(true);
+                }
+
                 // Add postMessage interface
                 class JsObject {
                     @JavascriptInterface


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

This PR allows opening local files in the inappbrowser for Android applications targeting SDK 30 or later. The use-case for this is the same as #693, but applicable to Android instead of iOS.

### Description

Starting with SDK 30, the default value for the `allowFileAccess` setting changed in Android (as [specified in the documentation](https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean))). It was `true` before and it's `false` now, meaning that this can potentially break existing applications.

This problem is something that has already been tackled in cordova core (Initially in https://github.com/apache/cordova-android/pull/1111, later updated in https://github.com/apache/cordova-android/pull/1222). So I just followed the same strategy and this setting is only updated if the `AndroidInsecureFileModeEnabled` preference is set to `true`.

### Testing

I've tested the fix in my application. Given that the code is quite simple and it's already in cordova core, I don't think it needs any further testing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
