### PR TITLE
New android only flag to keep screen on

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ instance, or the system browser.
     - __shouldPauseOnSuspend__: Set to `yes` to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues like described in [CB-11013](https://issues.apache.org/jira/browse/CB-11013)).
     - __useWideViewPort__: Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is `no`, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is `yes` and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to `yes`).
     - __fullscreen__: Sets whether the InappBrowser WebView is displayed fullscreen or not. In fullscreen mode, the status bar is hidden. Default value is `yes`.
+    - __keepscreenon__: Sets whether the InappBrowser WebView will keep the screen on or not. If enabled the screen stays on. (defaults to `no`).
 
     iOS supports these additional options:
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -116,6 +116,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
+    private static final String KEEP_SCREEN_ON = "keepscreenon"
 
     private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
@@ -145,6 +146,7 @@ public class InAppBrowser extends CordovaPlugin {
     private String footerColor = "";
     private String beforeload = "";
     private boolean fullscreen = true;
+    private boolean keepScreenOn = false;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
 
@@ -710,6 +712,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (fullscreenSet != null) {
                 fullscreen = fullscreenSet.equals("yes") ? true : false;
             }
+            String keepScreenOnSet = features.get(KEEP_SCREEN_ON);
+            if (keepScreenOnSet != null) {
+                keepScreenOn = keepScreenOnSet.equals("yes") ? true : false;
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -787,6 +793,9 @@ public class InAppBrowser extends CordovaPlugin {
                 dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
                 if (fullscreen) {
                     dialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+                if (keepScreenOn) {
+                    dialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                 }
                 dialog.setCancelable(true);
                 dialog.setInAppBroswer(getInAppBrowser());


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have a scenario where we show a page to the user with the in app browser and like to keep the screen on during that page.
The in app browser helps us got achieve an illusion that the screen is a part of the app.

@Hermarcel wrote a different scenario in the issue linked below.
Closes #876 


### Description
<!-- Describe your changes in detail -->
I've added a in app browser option flag to keep the screen on.
New flag: `keepscreenon`
Default: not enabled
Sets Android window flag: `WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)`



### Testing
<!-- Please describe in detail how you tested your changes. -->
I've performed the changes in our app first and tested it on a device.
- Set Screen timeout to 15s
- Navigating to the page -> screen keeps on
- Navigating back to the app -> flag gets cleared -> screen timeout works again

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
