### PR TITLE
(ios) Fixes #566

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -713,6 +713,8 @@ BOOL isExiting = FALSE;
         [self.webViewUIDelegate setViewController:self];
         
         [self createViews];
+        
+        self.modalInPopover = TRUE;
     }
     
     return self;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #566 by setting modalInPopover to true, disabling the swipe to dismiss feature. 


### Description
<!-- Describe your changes in detail -->
Sets modalInPopover to true, only allowing closing by "Done" button


### Testing
<!-- Please describe in detail how you tested your changes. -->
Created a pagesheet inAppBrowser and tried to close by swiping down. Got the unresponsive app as described in the bug report. Added my changed, rebuild and tried the same. The inAppBrowser is no longer closed, unless "Done" is pressed.


### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
