### PR TITLE
feat: Allow changing location bg and text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ instance, or the system browser.
     - __hideurlbar__: set to `yes` to hide the url bar on the location toolbar, only has effect if user has location set to `yes`. The default value is `no`.
     - __navigationbuttoncolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the color of both navigation buttons from default. Only has effect if user has location set to `yes` and not hidenavigationbuttons set to `yes`.
     - __toolbarcolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the color the toolbar from default. Only has effect if user has location set to `yes`.
+    - __locationtextcolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the color of the location text (URL) from default. Only has effect if user has location set to `yes`.
     - __lefttoright__: Set to `yes` to swap positions of the navigation buttons and the close button. Specifically, navigation buttons go to the right and close button to the left. Default value is `no`.
     - __zoom__: set to `yes` to show Android browser's zoom controls, set to `no` to hide them.  Default value is `yes`.
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).
@@ -140,6 +141,8 @@ instance, or the system browser.
     - __toolbar__:  set to `yes` or `no` to turn the toolbar on or off for the InAppBrowser (defaults to `yes`)
     - __toolbarcolor__: set as a valid hex color string, for example: `#00ff00`, to change from the default color of the toolbar. Only applicable if toolbar is not disabled.
     - __toolbartranslucent__:  set to `yes` or `no` to make the toolbar translucent(semi-transparent)  (defaults to `yes`). Only applicable if toolbar is not disabled.
+    - __locationcolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the color of the location bar from default. Only has effect if user has location set to `yes`.
+    - __locationtextcolor__: set to a valid hex color string, for example: `#00ff00`, and it will change the color of the location text (URL) from default. Only has effect if user has location set to `yes`.
     - __lefttoright__: Set to `yes` to swap positions of the navigation buttons and the close button. Specifically, close button goes to the right and navigation buttons to the left.
     - __enableViewportScale__:  Set to `yes` or `no` to prevent viewport scaling through a meta tag (defaults to `no`).
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -116,8 +116,9 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
+    private static final String LOCATION_TEXT_COLOR = "locationtextcolor";
 
-    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
+    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR, LOCATION_TEXT_COLOR);
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
@@ -145,6 +146,7 @@ public class InAppBrowser extends CordovaPlugin {
     private String footerColor = "";
     private String beforeload = "";
     private boolean fullscreen = true;
+    private String locationTextColor = "";
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
 
@@ -710,6 +712,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (fullscreenSet != null) {
                 fullscreen = fullscreenSet.equals("yes") ? true : false;
             }
+            String locationTextColorSet = features.get(LOCATION_TEXT_COLOR);
+            if (locationTextColorSet != null) {
+                locationTextColor = locationTextColorSet;
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -870,6 +876,7 @@ public class InAppBrowser extends CordovaPlugin {
                 textLayoutParams.addRule(RelativeLayout.LEFT_OF, 5);
                 edittext.setLayoutParams(textLayoutParams);
                 edittext.setId(Integer.valueOf(4));
+                if (locationTextColor != "") edittext.setTextColor(android.graphics.Color.parseColor(locationTextColor));
                 edittext.setSingleLine(true);
                 edittext.setText(url);
                 edittext.setInputType(InputType.TYPE_TEXT_VARIATION_URI);

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -27,6 +27,8 @@
 @property (nonatomic, assign) BOOL lefttoright;
 @property (nonatomic, copy) NSString* toolbarposition;
 @property (nonatomic, copy) NSString* toolbarcolor;
+@property (nonatomic, copy) NSString* locationcolor;
+@property (nonatomic, copy) NSString* locationtextcolor;
 @property (nonatomic, assign) BOOL toolbartranslucent;
 @property (nonatomic, assign) BOOL hidenavigationbuttons;
 @property (nonatomic, copy) NSString* navigationbuttoncolor;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -43,6 +43,8 @@
         self.closebuttoncolor = nil;
         self.lefttoright = false;
         self.toolbarcolor = nil;
+        self.locationcolor = nil;
+        self.locationtextcolor = nil;
         self.toolbartranslucent = YES;
         self.beforeload = @"";
     }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -856,7 +856,11 @@ BOOL isExiting = FALSE;
     self.addressLabel.alpha = 1.000;
     self.addressLabel.autoresizesSubviews = YES;
     self.addressLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
-    self.addressLabel.backgroundColor = [UIColor clearColor];
+    if (_browserOptions.locationcolor != nil) { // Set background color if user sets it in options
+        self.addressLabel.backgroundColor = [self colorFromHexString:_browserOptions.locationcolor];
+    } else {
+        self.addressLabel.backgroundColor = [UIColor clearColor];
+    }
     self.addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
     self.addressLabel.clearsContextBeforeDrawing = YES;
     self.addressLabel.clipsToBounds = YES;
@@ -864,20 +868,24 @@ BOOL isExiting = FALSE;
     self.addressLabel.enabled = YES;
     self.addressLabel.hidden = NO;
     self.addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-    
+
     if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumScaleFactor:")]) {
         [self.addressLabel setValue:@(10.0/[UIFont labelFontSize]) forKey:@"minimumScaleFactor"];
     } else if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumFontSize:")]) {
         [self.addressLabel setValue:@(10.0) forKey:@"minimumFontSize"];
     }
-    
+
     self.addressLabel.multipleTouchEnabled = NO;
     self.addressLabel.numberOfLines = 1;
     self.addressLabel.opaque = NO;
     self.addressLabel.shadowOffset = CGSizeMake(0.0, -1.0);
     self.addressLabel.text = NSLocalizedString(@"Loading...", nil);
     self.addressLabel.textAlignment = NSTextAlignmentLeft;
-    self.addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
+    if (_browserOptions.locationtextcolor != nil) { // Set text color if user sets it in options
+        self.addressLabel.textColor = [self colorFromHexString:_browserOptions.locationtextcolor];
+    } else {
+        self.addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
+    }
     self.addressLabel.userInteractionEnabled = NO;
     
     NSString* frontArrowString = NSLocalizedString(@"►", nil); // create arrow from Unicode char


### PR DESCRIPTION
### Platforms affected
Android
iOS


### Motivation and Context
This PR allows changing the color of the URL text (Android & iOS) and also the background color of the location bar (iOS only). The plugin allows changing the color of other elements (toolbar, navigation buttons, close button) so it makes sense to also be able to change these colors.



### Description
I added 2 new options: one for Android&iOS and one for iOS only to allow changing the colors.



### Testing
Open the InAppBrowser passing the options "locationcolor" and "locationtextcolor" to any value you want and check that the location background (iOS only) and text changes to the colors you specified.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
