### PR TITLE
Add loadstart, loadstop and loaderror events for calls with the _syst…

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -359,10 +359,25 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
+    CDVPluginResult* loadStartResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                  messageAsDictionary:@{@"type":@"loadstart", @"url":[url absoluteString]}];
+    [loadStartResult setKeepCallback:[NSNumber numberWithBool:YES]];
+    [self.commandDelegate sendPluginResult:loadStartResult callbackId:self.callbackId];
+
     if ([[UIApplication sharedApplication] openURL:url] == NO) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                      messageAsDictionary:@{@"type":@"loaderror", @"url":[url absoluteString], @"code": @"-1", @"message": @"Tried to open the url, but it failed"}];
+        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
         [[UIApplication sharedApplication] openURL:url];
     }
+
+    CDVPluginResult* loadStopResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                  messageAsDictionary:@{@"type":@"loadstop", @"url":[url absoluteString]}];
+    [loadStopResult setKeepCallback:[NSNumber numberWithBool:YES]];
+    [self.commandDelegate sendPluginResult:loadStopResult callbackId:self.callbackId];
 }
 
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
### Platforms affected
iOS and Android


### Motivation and Context
No events are raised when using the `_system` target on either iOS or Android. I've added support for them in this PR.

This should fix issue [730]

### Description
I've added code to raise the loadstart, loadstop and loaderror events at the appropriate times.

### Testing
I've tested my changes manually.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
