### PR TITLE
feat(ios): explicitly import headers

### DIFF
--- a/src/ios/CDVInAppBrowserNavigationController.h
+++ b/src/ios/CDVInAppBrowserNavigationController.h
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <UIKit/UINavigationController.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
 
 

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <Foundation/Foundation.h>
 
 @interface CDVInAppBrowserOptions : NSObject {}
 


### PR DESCRIPTION
dependencies, instead of relying on PCH files. This is important in Swift projects, where you cannot use prefix headers.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
Cannot add plugin to Swift-based project with embedded WKWebView, because it relies on prefix header, which is not supported in Swift projects.



### Description
Explicitly import needed files, so we don't need to rely on PCH files.



### Testing
Built successfully in ObjC and Swift based projects.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
