### PR TITLE
(android) New 'enablethirdpartycookies' option and code clean-ups

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -124,9 +124,9 @@ public class InAppBrowser extends CordovaPlugin {
         CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
     // Resources
-	private static final String TOOLBAR_CLOSE_BUTTON = "ic_action_remove";
-	private static final String TOOLBAR_BACK_BUTTON = "ic_action_previous_item";
-	private static final String TOOLBAR_FORWARD_BUTTON = "ic_action_next_item";
+    private static final String TOOLBAR_CLOSE_BUTTON = "ic_action_remove";
+    private static final String TOOLBAR_BACK_BUTTON = "ic_action_previous_item";
+    private static final String TOOLBAR_FORWARD_BUTTON = "ic_action_next_item";
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -130,7 +130,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean openWindowHidden = false;
     private boolean clearAllCache = false;
     private boolean clearSessionCache = false;
-    private boolean hadwareBackButton = true;
+    private boolean hardwareBackButton = true;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
     private boolean useWideViewPort = true;
@@ -576,7 +576,7 @@ public class InAppBrowser extends CordovaPlugin {
      * @return boolean
      */
     public boolean hardwareBack() {
-        return hadwareBackButton;
+        return hardwareBackButton;
     }
 
     /**
@@ -626,12 +626,6 @@ public class InAppBrowser extends CordovaPlugin {
      * @param features jsonObject
      */
     public String showWebPage(final String url, HashMap<String, String> features) {
-        // Determine if we should hide the location bar.
-        showLocationBar = true;
-        showZoomControls = true;
-        openWindowHidden = false;
-        mediaPlaybackRequiresUserGesture = false;
-
         if (features != null) {
             String show = features.get(LOCATION);
             if (show != null) {
@@ -653,9 +647,9 @@ public class InAppBrowser extends CordovaPlugin {
             }
             String hardwareBack = features.get(HARDWARE_BACK_BUTTON);
             if (hardwareBack != null) {
-                hadwareBackButton = hardwareBack.equals("yes") ? true : false;
+                hardwareBackButton = hardwareBack.equals("yes") ? true : false;
             } else {
-                hadwareBackButton = DEFAULT_HARDWARE_BACK;
+                hardwareBackButton = DEFAULT_HARDWARE_BACK;
             }
             String mediaPlayback = features.get(MEDIA_PLAYBACK_REQUIRES_USER_ACTION);
             if (mediaPlayback != null) {

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -119,7 +119,8 @@ public class InAppBrowser extends CordovaPlugin {
 
     private static final int TOOLBAR_HEIGHT = 48;
 
-    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
+    private static final List customizableOptions = Arrays.asList(
+        CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -122,6 +122,11 @@ public class InAppBrowser extends CordovaPlugin {
     private static final List customizableOptions = Arrays.asList(
         CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
 
+    // Resources
+	private static final String TOOLBAR_CLOSE_BUTTON = "ic_action_remove";
+	private static final String TOOLBAR_BACK_BUTTON = "ic_action_previous_item";
+	private static final String TOOLBAR_FORWARD_BUTTON = "ic_action_next_item";
+
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
     private EditText edittext;
@@ -619,6 +624,15 @@ public class InAppBrowser extends CordovaPlugin {
     private InAppBrowser getInAppBrowser() {
         return this;
     }
+	
+    /**
+     * Get a drawable by name from the main package.
+     */
+    private Drawable getDrawableFromResources(String name){
+        Resources activityRes = cordova.getActivity().getResources();
+        int resId = activityRes.getIdentifier(name, "drawable", cordova.getActivity().getPackageName());
+        return activityRes.getDrawable(resId, cordova.getActivity().getTheme());
+    }
 
     /**
      * Display a new browser with the specified URL.
@@ -743,8 +757,7 @@ public class InAppBrowser extends CordovaPlugin {
                 }
                 else {
                     ImageButton close = new ImageButton(cordova.getActivity());
-                    int closeResId = activityRes.getIdentifier("ic_action_remove", "drawable", cordova.getActivity().getPackageName());
-                    Drawable closeIcon = activityRes.getDrawable(closeResId);
+                    Drawable closeIcon = getDrawableFromResources(TOOLBAR_CLOSE_BUTTON);
                     if (closeButtonColor != "") close.setColorFilter(android.graphics.Color.parseColor(closeButtonColor));
                     close.setImageDrawable(closeIcon);
                     close.setScaleType(ImageView.ScaleType.FIT_CENTER);
@@ -823,8 +836,7 @@ public class InAppBrowser extends CordovaPlugin {
                 back.setContentDescription("Back Button");
                 back.setId(Integer.valueOf(2));
                 Resources activityRes = cordova.getActivity().getResources();
-                int backResId = activityRes.getIdentifier("ic_action_previous_item", "drawable", cordova.getActivity().getPackageName());
-                Drawable backIcon = activityRes.getDrawable(backResId);
+                Drawable backIcon = getDrawableFromResources(TOOLBAR_BACK_BUTTON);
                 if (navigationButtonColor != "") back.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
                 back.setBackground(null);
                 back.setImageDrawable(backIcon);
@@ -845,8 +857,7 @@ public class InAppBrowser extends CordovaPlugin {
                 forward.setLayoutParams(forwardLayoutParams);
                 forward.setContentDescription("Forward Button");
                 forward.setId(Integer.valueOf(3));
-                int fwdResId = activityRes.getIdentifier("ic_action_next_item", "drawable", cordova.getActivity().getPackageName());
-                Drawable fwdIcon = activityRes.getDrawable(fwdResId);
+                Drawable fwdIcon = getDrawableFromResources(TOOLBAR_FORWARD_BUTTON);
                 if (navigationButtonColor != "") forward.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
                 forward.setBackground(null);
                 forward.setImageDrawable(fwdIcon);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -100,6 +100,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String MESSAGE_EVENT = "message";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
+    private static final String ENABLE_THIRD_PARTY_COOKIES = "enablethirdpartycookies";
     private static final String HARDWARE_BACK_BUTTON = "hardwareback";
     private static final String MEDIA_PLAYBACK_REQUIRES_USER_ACTION = "mediaPlaybackRequiresUserAction";
     private static final String SHOULD_PAUSE = "shouldPauseOnSuspend";
@@ -136,6 +137,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean openWindowHidden = false;
     private boolean clearAllCache = false;
     private boolean clearSessionCache = false;
+    private boolean enableThirdPartyCookies = true;
     private boolean hardwareBackButton = true;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
@@ -679,6 +681,10 @@ public class InAppBrowser extends CordovaPlugin {
                     clearSessionCache = cache.equals("yes") ? true : false;
                 }
             }
+            String thirdPartyCookies = features.get(ENABLE_THIRD_PARTY_COOKIES);
+            if (thirdPartyCookies != null) {
+                enableThirdPartyCookies = thirdPartyCookies.equals("yes") ? true : false;
+            }
             String shouldPause = features.get(SHOULD_PAUSE);
             if (shouldPause != null) {
                 shouldPauseInAppBrowser = shouldPause.equals("yes") ? true : false;
@@ -807,7 +813,7 @@ public class InAppBrowser extends CordovaPlugin {
 
                 // Toolbar layout
                 RelativeLayout toolbar = new RelativeLayout(cordova.getActivity());
-                //Please, no more black!
+                //"Please, no more black!" <- who said this?!? Black is awesome, especially on OLED! ^^
                 toolbar.setBackgroundColor(toolbarColor);
                 toolbar.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(TOOLBAR_HEIGHT)));
                 toolbar.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
@@ -998,7 +1004,7 @@ public class InAppBrowser extends CordovaPlugin {
                 }
 
                 // Enable Thirdparty Cookies
-                CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView,true);
+                CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView, enableThirdPartyCookies);
 
                 inAppWebView.loadUrl(url);
                 inAppWebView.setId(Integer.valueOf(6));


### PR DESCRIPTION
### Platforms affected

Android.

### Motivation and Context

- Third party cookies should be configurable and not just simply on by default
- I've done some additional code improvements to better handle resources
- Fixed a type and some potentially confusing, redundant code

### Description

- Third party cookies are often used for tracking and thus should at least be configurable.
- The code for loading drawables kept repeating so I decided to introduce a function to handle it and making it easier to adapt in case of changes. In addition I thought it was useful to handle all required resources as static variables at the top.
- 'hardwarebackbutton' was misspelled, so I fixed that.
- 'showWebPage' redefined some defaults that were already defined at the top which could be very confusing if the default has to be changed in the future.
- Minor code clean-ups for better readability.

Note: I noticed there is a lot more potential for optimizing the code. Android Studio itself is already pointing out several simplifications. If there is enough interest I'd consider creating another PR :-).

### Testing

- Built the app with the new version
- Checked if browser loads as expected
- Changed third party cookie support with new option
- Testes results with `https://www.whatismybrowser.com/detect/are-third-party-cookies-enabled`
- All working as expected :-)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
