### PR TITLE
fix(GH-706): (android) Allow permissions requests

### DIFF
--- a/src/android/InAppChromeClient.java
+++ b/src/android/InAppChromeClient.java
@@ -34,6 +34,7 @@ import android.webkit.WebStorage;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.GeolocationPermissions.Callback;
+import android.webkit.PermissionRequest;
 
 public class InAppChromeClient extends WebChromeClient {
 
@@ -45,6 +46,13 @@ public class InAppChromeClient extends WebChromeClient {
         super();
         this.webView = webView;
     }
+    
+    public void onPermissionRequest(final PermissionRequest request) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            request.grant(request.getResources());
+        }
+    }
+
     /**
      * Handle database quota exceeded notification.
      *


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
Android in-app-browser does not allow in-browser camera/webcamera usage (permission denied)
With this change, camera usage will be allowed as long as the app has permissions.
Issue GH-706: https://github.com/apache/cordova-plugin-inappbrowser/issues/706


### Description
Allows permissions requests from ChromeWebView



### Testing
IAB would show permissions denied error in website https://webcam-test.com/
After the changes it successfuly works (requires app's camera permission to be enabled)



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
