### PR TITLE
Set webView.inspectable to true on iOS >= 16.4

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -778,6 +778,14 @@ BOOL isExiting = FALSE;
     [self.view addSubview:self.webView];
     [self.view sendSubviewToBack:self.webView];
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+    // Set "inspectable" to true for backwards compatibility with iOS <= 16.3, but allow an override.
+    // Preferably this would be set to the default "NO" or wrapped in an "#ifdef DEBUG",
+    // but that would be a breaking change and needs to wait till a (next) major release.
+    if (@available(iOS 16.4, *)) {
+        self.webView.inspectable = [settings cordovaBoolSettingForKey:@"InspectableWebview" defaultValue:YES];;
+    }
+#endif
     
     self.webView.navigationDelegate = self;
     self.webView.UIDelegate = self.webViewUIDelegate;


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

With the introduction of iOS 16.4 WKWebView instances will no longer be inspectable by default.

Details: [Enabling the Inspection of Web Content in Apps](https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/)

### Description

This PR explicitly sets the inspectability to `YES` again for backwards compatibility, but offers an override option.

Preferably this new setting would be set to the default `NO` or wrapped in an `#ifdef DEBUG`, but that would be a breaking change and needs to wait till a (next) major release.

### Testing

Tested the code in one of our own apps.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
