### PR TITLE
(android)Full screen support for android html video

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ instance, or the system browser.
     - __shouldPauseOnSuspend__: Set to `yes` to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues like described in [CB-11013](https://issues.apache.org/jira/browse/CB-11013)).
     - __useWideViewPort__: Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport. When the value of the setting is `no`, the layout width is always set to the width of the WebView control in device-independent (CSS) pixels. When the value is `yes` and the page contains the viewport meta tag, the value of the width specified in the tag is used. If the page does not contain the tag or does not provide a width, then a wide viewport will be used. (defaults to `yes`).
     - __fullscreen__: Sets whether the InappBrowser WebView is displayed fullscreen or not. In fullscreen mode, the status bar is hidden. Default value is `yes`.
+    - __videoFullscreen__: Sets whether the InappBrowser WebView in full screen when clicking the full screen button of the video of html. Default value is `no`.
 
     iOS supports these additional options:
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,7 @@
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
+        <source-file src="src/android/InAppVideoChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
 
         <!-- drawable src/android/resources -->
         <resource-file src="src/android/res/drawable-hdpi/ic_action_next_item.png" target="res/drawable-hdpi/ic_action_next_item.png" />

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -35,10 +35,13 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.WindowManager.LayoutParams;
@@ -56,6 +59,7 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -116,6 +120,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
+    private static final String VIDEO_FULLSCREEN = "videofullscreen";
 
     private static final int TOOLBAR_HEIGHT = 48;
 
@@ -149,6 +154,11 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean fullscreen = true;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
+
+    //Video FullScreen
+    private boolean useVideoFullScreen = false;
+    private FullscreenHolder fullscreenHolder;
+    private InAppVideoChromeClient.InAppVideoFullScreenHelper videoHelper;
 
     /**
      * Executes the request and returns PluginResult.
@@ -558,6 +568,14 @@ public class InAppBrowser extends CordovaPlugin {
      * Checks to see if it is possible to go back one page in history, then does so.
      */
     public void goBack() {
+        //if useVideo FullScreen
+        if (useVideoFullScreen) {
+            //check fullscreen and goback
+            if(videoHelper.goBack()) {
+                return;
+            }
+        }
+
         if (this.inAppWebView.canGoBack()) {
             this.inAppWebView.goBack();
         }
@@ -711,6 +729,10 @@ public class InAppBrowser extends CordovaPlugin {
             String fullscreenSet = features.get(FULLSCREEN);
             if (fullscreenSet != null) {
                 fullscreen = fullscreenSet.equals("yes") ? true : false;
+            }
+            String videoFullscreen = features.get(VIDEO_FULLSCREEN);
+            if (videoFullscreen != null) {
+                useVideoFullScreen = videoFullscreen.equals("yes") ? true : false;
             }
         }
 
@@ -922,23 +944,25 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
                     public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
                     {
-                        LOG.d(LOG_TAG, "File Chooser 5.0+");
-                        // If callback exists, finish it.
-                        if(mUploadCallback != null) {
-                            mUploadCallback.onReceiveValue(null);
-                        }
-                        mUploadCallback = filePathCallback;
-
-                        // Create File Chooser Intent
-                        Intent content = new Intent(Intent.ACTION_GET_CONTENT);
-                        content.addCategory(Intent.CATEGORY_OPENABLE);
-                        content.setType("*/*");
-
-                        // Run cordova startActivityForResult
-                        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE);
+                        openFileChooser(filePathCallback);
                         return true;
                     }
                 });
+                // if useVideoFullScreen  
+                if (useVideoFullScreen) {
+                    // init holder
+                    fullscreenHolder = new FullscreenHolder(cordova.getContext());
+                    // init videoHelper
+                    videoHelper = new InAppVideoChromeClient.InAppVideoFullScreenHelper(cordova.getActivity(), fullscreenHolder);
+                    // change to InAppVideoChromeClient
+                    inAppWebView.setWebChromeClient(new InAppVideoChromeClient(thatWebView,videoHelper) {
+                        public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
+                        {
+                            openFileChooser(filePathCallback);
+                            return true;
+                        }
+                    });
+                }
                 currentClient = new InAppBrowserClient(thatWebView, edittext, beforeload);
                 inAppWebView.setWebViewClient(currentClient);
                 WebSettings settings = inAppWebView.getSettings();
@@ -1021,6 +1045,10 @@ public class InAppBrowser extends CordovaPlugin {
                 // Add our webview to our main view/layout
                 RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());
                 webViewLayout.addView(inAppWebView);
+                if(useVideoFullScreen) {
+                    // if useVideoFullSceen add FullScreenHolder
+                    webViewLayout.addView(fullscreenHolder,new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,ViewGroup.LayoutParams.MATCH_PARENT));
+                }
                 main.addView(webViewLayout);
 
                 // Don't add the footer unless it's been enabled
@@ -1459,6 +1487,37 @@ public class InAppBrowser extends CordovaPlugin {
 
             // By default handle 401 like we'd normally do!
             super.onReceivedHttpAuthRequest(view, handler, host, realm);
+        }
+    }
+
+    // bind the same function For ChromeClient
+    private void openFileChooser(ValueCallback<Uri[]> filePathCallback) {
+        LOG.d(LOG_TAG, "File Chooser 5.0+");
+        // If callback exists, finish it.
+        if(mUploadCallback != null) {
+            mUploadCallback.onReceiveValue(null);
+        }
+        mUploadCallback = filePathCallback;
+
+        // Create File Chooser Intent
+        Intent content = new Intent(Intent.ACTION_GET_CONTENT);
+        content.addCategory(Intent.CATEGORY_OPENABLE);
+        content.setType("*/*");
+
+        // Run cordova startActivityForResult
+        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE);
+    }
+
+    //FullScreen Video Helper Method
+    private static class FullscreenHolder extends FrameLayout {
+        public FullscreenHolder(Context context) {
+            super(context);
+            setBackgroundColor(Color.BLACK);
+            setVisibility(View.INVISIBLE);
+        }
+        @Override
+        public boolean onTouchEvent(MotionEvent evt) {
+            return true;
         }
     }
 }

--- a/src/android/InAppVideoChromeClient.java
+++ b/src/android/InAppVideoChromeClient.java
@@ -1,0 +1,108 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.inappbrowser;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.GeolocationPermissions.Callback;
+import android.webkit.JsPromptResult;
+import android.webkit.WebChromeClient;
+import android.webkit.WebStorage;
+import android.webkit.WebView;
+import android.widget.FrameLayout;
+
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.LOG;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class InAppVideoChromeClient extends InAppChromeClient {
+
+    InAppVideoFullScreenHelper helper;
+    public InAppVideoChromeClient(CordovaWebView webView ,InAppVideoFullScreenHelper helper) {
+        super(webView);
+        this.helper = helper;
+    }
+
+    @Override
+    public void onShowCustomView(View view, CustomViewCallback callback) {
+       helper.onShowCustomView(view,callback);
+    }
+
+    @Override
+    public void onShowCustomView(View view, int requestedOrientation, CustomViewCallback callback) {
+        super.onShowCustomView(view,callback);
+    }
+
+    @Override
+    public void onHideCustomView() {
+       helper.onHideCustomView();
+    }
+
+    public static class InAppVideoFullScreenHelper {
+        Activity activity;
+        FrameLayout holder;
+
+        private int originalOrientation;
+        private View customView;
+        private WebChromeClient.CustomViewCallback customViewCallback;
+
+        public InAppVideoFullScreenHelper(Activity activity, FrameLayout holder) {
+            this.activity = activity;
+            this.holder = holder;
+        }
+
+        public void onShowCustomView(View view, WebChromeClient.CustomViewCallback callback) {
+            holder.addView(view, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+            customView = view;
+            customViewCallback = callback;
+            originalOrientation = activity.getRequestedOrientation();
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            holder.setVisibility(View.VISIBLE);
+        }
+
+        private void resetValues() {
+            activity.setRequestedOrientation(originalOrientation);
+            holder.removeView(customView);
+            customViewCallback.onCustomViewHidden();
+            customView = null;
+            customViewCallback = null;
+            holder.setVisibility(View.INVISIBLE);
+        }
+
+        public void onHideCustomView() {
+            if (customView == null) {
+                return;
+            }
+            resetValues();
+        }
+
+        public boolean goBack() {
+            if (customView == null) {
+                return false;
+            }
+            resetValues();
+            return true;
+        }
+    }
+
+}


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Support FullScreen For Android Video in html

### Description
Android WebView is Not Support FullScreen Video in html
So we need some extra work on the "chromeClient".

### Testing
Tested the code in one of our own apps.


### Checklist

- [x ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
