### PR TITLE
chore: use https urls in tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can show helpful articles, videos, and web resources inside of your app. Use
 
 This plugin provides a web browser view that displays when calling `cordova.InAppBrowser.open()`.
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
 
 ### `window.open`
 
@@ -166,7 +166,7 @@ instance, or the system browser.
 
 ### Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     var ref2 = cordova.InAppBrowser.open(encodeURI('http://ja.m.wikipedia.org/wiki/ハングル'), '_blank', 'location=yes');
 
 ### OSX Quirks
@@ -353,7 +353,7 @@ function messageCallBack(params){
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstart', function(event) { alert(event.url); });
 
 ## InAppBrowser.removeEventListener
@@ -384,7 +384,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     var myCallback = function(event) { alert(event.url); }
     ref.addEventListener('loadstart', myCallback);
     ref.removeEventListener('loadstart', myCallback);
@@ -406,7 +406,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     ref.close();
 
 ## InAppBrowser.show
@@ -426,7 +426,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'hidden=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'hidden=yes');
     // some time later...
     ref.show();
 
@@ -446,7 +446,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank');
     // some time later...
     ref.hide();
 
@@ -478,7 +478,7 @@ The function is passed an `InAppBrowserEvent` object.
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstop', function() {
         ref.executeScript({file: "myscript.js"});
     });
@@ -513,7 +513,7 @@ Due to [MSDN docs](https://msdn.microsoft.com/en-us/library/windows.ui.xaml.cont
 
 ### Quick Example
 
-    var ref = cordova.InAppBrowser.open('http://apache.org', '_blank', 'location=yes');
+    var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstop', function() {
         ref.insertCSS({file: "mystyles.css"});
     });
@@ -695,13 +695,13 @@ iab.open('local-url.html', 'random_string', 'location=no'); // loads in the InAp
 ```
 var iab = cordova.InAppBrowser;
 
-iab.open('http://whitelisted-url.com');                  // loads in the Cordova WebView
-iab.open('http://whitelisted-url.com', '_self');         // loads in the Cordova WebView
-iab.open('http://whitelisted-url.com', '_system');       // loads in the system browser
-iab.open('http://whitelisted-url.com', '_blank');        // loads in the InAppBrowser
-iab.open('http://whitelisted-url.com', 'random_string'); // loads in the InAppBrowser
+iab.open('https://whitelisted-url.com');                  // loads in the Cordova WebView
+iab.open('https://whitelisted-url.com', '_self');         // loads in the Cordova WebView
+iab.open('https://whitelisted-url.com', '_system');       // loads in the system browser
+iab.open('https://whitelisted-url.com', '_blank');        // loads in the InAppBrowser
+iab.open('https://whitelisted-url.com', 'random_string'); // loads in the InAppBrowser
 
-iab.open('http://whitelisted-url.com', 'random_string', 'location=no'); // loads in the InAppBrowser, no location bar
+iab.open('https://whitelisted-url.com', 'random_string', 'location=no'); // loads in the InAppBrowser, no location bar
 
 ```
 
@@ -710,11 +710,11 @@ iab.open('http://whitelisted-url.com', 'random_string', 'location=no'); // loads
 ```
 var iab = cordova.InAppBrowser;
 
-iab.open('http://url-that-fails-whitelist.com');                  // loads in the InAppBrowser
-iab.open('http://url-that-fails-whitelist.com', '_self');         // loads in the InAppBrowser
-iab.open('http://url-that-fails-whitelist.com', '_system');       // loads in the system browser
-iab.open('http://url-that-fails-whitelist.com', '_blank');        // loads in the InAppBrowser
-iab.open('http://url-that-fails-whitelist.com', 'random_string'); // loads in the InAppBrowser
-iab.open('http://url-that-fails-whitelist.com', 'random_string', 'location=no'); // loads in the InAppBrowser, no location bar
+iab.open('https://url-that-fails-whitelist.com');                  // loads in the InAppBrowser
+iab.open('https://url-that-fails-whitelist.com', '_self');         // loads in the InAppBrowser
+iab.open('https://url-that-fails-whitelist.com', '_system');       // loads in the system browser
+iab.open('https://url-that-fails-whitelist.com', '_blank');        // loads in the InAppBrowser
+iab.open('https://url-that-fails-whitelist.com', 'random_string'); // loads in the InAppBrowser
+iab.open('https://url-that-fails-whitelist.com', 'random_string', 'location=no'); // loads in the InAppBrowser, no location bar
 
 ```

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -657,49 +657,49 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         '* target=Default',
         function () {
-            doOpen('http://cordova.apache.org');
+            doopen('https://cordova.apache.org');
         },
         'openWhiteListed'
     );
     createActionButton(
         '* target=Default (window.open)',
         function () {
-            doHookOpen('http://cordova.apache.org');
+            doHookopen('https://cordova.apache.org');
         },
         'openWhiteListedHook'
     );
     createActionButton(
         '* target=_self',
         function () {
-            doOpen('http://cordova.apache.org', '_self');
+            doopen('https://cordova.apache.org', '_self');
         },
         'openWhiteListedSelf'
     );
     createActionButton(
         'target=_system',
         function () {
-            doOpen('http://cordova.apache.org', '_system');
+            doopen('https://cordova.apache.org', '_system');
         },
         'openWhiteListedSystem'
     );
     createActionButton(
         'target=_blank',
         function () {
-            doOpen('http://cordova.apache.org', '_blank');
+            doopen('https://cordova.apache.org', '_blank');
         },
         'openWhiteListedBlank'
     );
     createActionButton(
         'target=Random',
         function () {
-            doOpen('http://cordova.apache.org', 'random_string');
+            doopen('https://cordova.apache.org', 'random_string');
         },
         'openWhiteListedRandom'
     );
     createActionButton(
         '* target=Random, no location bar',
         function () {
-            doOpen('http://cordova.apache.org', 'random_string', 'location=no');
+            doopen('https://cordova.apache.org', 'random_string', 'location=no');
         },
         'openWhiteListedRandomNoLocation'
     );
@@ -708,49 +708,49 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'target=Default',
         function () {
-            doOpen('http://www.apple.com');
+            doopen('https://www.apple.com');
         },
         'openNonWhiteListed'
     );
     createActionButton(
         'target=Default (window.open)',
         function () {
-            doHookOpen('http://www.apple.com');
+            doHookopen('https://www.apple.com');
         },
         'openNonWhiteListedHook'
     );
     createActionButton(
         'target=_self',
         function () {
-            doOpen('http://www.apple.com', '_self');
+            doopen('https://www.apple.com', '_self');
         },
         'openNonWhiteListedSelf'
     );
     createActionButton(
         'target=_system',
         function () {
-            doOpen('http://www.apple.com', '_system');
+            doopen('https://www.apple.com', '_system');
         },
         'openNonWhiteListedSystem'
     );
     createActionButton(
         'target=_blank',
         function () {
-            doOpen('http://www.apple.com', '_blank');
+            doopen('https://www.apple.com', '_blank');
         },
         'openNonWhiteListedBlank'
     );
     createActionButton(
         'target=Random',
         function () {
-            doOpen('http://www.apple.com', 'random_string');
+            doopen('https://www.apple.com', 'random_string');
         },
         'openNonWhiteListedRandom'
     );
     createActionButton(
         '* target=Random, no location bar',
         function () {
-            doOpen('http://www.apple.com', 'random_string', 'location=no');
+            doopen('https://www.apple.com', 'random_string', 'location=no');
         },
         'openNonWhiteListedRandomNoLocation'
     );
@@ -759,14 +759,14 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'http://google.co.uk',
         function () {
-            doOpen('http://google.co.uk', 'random_string', '', 1);
+            doopen('https://google.co.uk', 'random_string', '', 1);
         },
         'openRedirect301'
     );
     createActionButton(
         'http://goo.gl/pUFqg',
         function () {
-            doOpen('http://goo.gl/pUFqg', 'random_string', '', 2);
+            doopen('https://goo.gl/pUFqg', 'random_string', '', 2);
         },
         'openRedirect302'
     );
@@ -775,7 +775,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'Remote URL',
         function () {
-            doOpen('http://www.stluciadance.com/prospectus_file/sample.pdf');
+            doopen('https://www.stluciadance.com/prospectus_file/sample.pdf');
         },
         'openPDF'
     );
@@ -798,7 +798,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'Invalid Host',
         function () {
-            doOpen('http://www.inv;alid.com/', '_blank');
+            doopen('https://www.inv;alid.com/', '_blank');
         },
         'openInvalidHost'
     );
@@ -974,21 +974,21 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'no hardwareback (defaults to yes)',
         function () {
-            doOpen('http://cordova.apache.org', '_blank');
+            doopen('https://cordova.apache.org', '_blank');
         },
         'openHardwareBackDefault'
     );
     createActionButton(
         'hardwareback=yes',
         function () {
-            doOpen('http://cordova.apache.org', '_blank', 'hardwareback=yes');
+            doopen('https://cordova.apache.org', '_blank', 'hardwareback=yes');
         },
         'openHardwareBackYes'
     );
     createActionButton(
         'hardwareback=no',
         function () {
-            doOpen('http://cordova.apache.org', '_blank', 'hardwareback=no');
+            doopen('https://cordova.apache.org', '_blank', 'hardwareback=no');
         },
         'openHardwareBackNo'
     );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -657,49 +657,49 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         '* target=Default',
         function () {
-            doopen('https://cordova.apache.org');
+            doOpen('https://cordova.apache.org');
         },
         'openWhiteListed'
     );
     createActionButton(
         '* target=Default (window.open)',
         function () {
-            doHookopen('https://cordova.apache.org');
+            doHookOpen('https://cordova.apache.org');
         },
         'openWhiteListedHook'
     );
     createActionButton(
         '* target=_self',
         function () {
-            doopen('https://cordova.apache.org', '_self');
+            doOpen('https://cordova.apache.org', '_self');
         },
         'openWhiteListedSelf'
     );
     createActionButton(
         'target=_system',
         function () {
-            doopen('https://cordova.apache.org', '_system');
+            doOpen('https://cordova.apache.org', '_system');
         },
         'openWhiteListedSystem'
     );
     createActionButton(
         'target=_blank',
         function () {
-            doopen('https://cordova.apache.org', '_blank');
+            doOpen('https://cordova.apache.org', '_blank');
         },
         'openWhiteListedBlank'
     );
     createActionButton(
         'target=Random',
         function () {
-            doopen('https://cordova.apache.org', 'random_string');
+            doOpen('https://cordova.apache.org', 'random_string');
         },
         'openWhiteListedRandom'
     );
     createActionButton(
         '* target=Random, no location bar',
         function () {
-            doopen('https://cordova.apache.org', 'random_string', 'location=no');
+            doOpen('https://cordova.apache.org', 'random_string', 'location=no');
         },
         'openWhiteListedRandomNoLocation'
     );
@@ -708,49 +708,49 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'target=Default',
         function () {
-            doopen('https://www.apple.com');
+            doOpen('https://www.apple.com');
         },
         'openNonWhiteListed'
     );
     createActionButton(
         'target=Default (window.open)',
         function () {
-            doHookopen('https://www.apple.com');
+            doHookOpen('https://www.apple.com');
         },
         'openNonWhiteListedHook'
     );
     createActionButton(
         'target=_self',
         function () {
-            doopen('https://www.apple.com', '_self');
+            doOpen('https://www.apple.com', '_self');
         },
         'openNonWhiteListedSelf'
     );
     createActionButton(
         'target=_system',
         function () {
-            doopen('https://www.apple.com', '_system');
+            doOpen('https://www.apple.com', '_system');
         },
         'openNonWhiteListedSystem'
     );
     createActionButton(
         'target=_blank',
         function () {
-            doopen('https://www.apple.com', '_blank');
+            doOpen('https://www.apple.com', '_blank');
         },
         'openNonWhiteListedBlank'
     );
     createActionButton(
         'target=Random',
         function () {
-            doopen('https://www.apple.com', 'random_string');
+            doOpen('https://www.apple.com', 'random_string');
         },
         'openNonWhiteListedRandom'
     );
     createActionButton(
         '* target=Random, no location bar',
         function () {
-            doopen('https://www.apple.com', 'random_string', 'location=no');
+            doOpen('https://www.apple.com', 'random_string', 'location=no');
         },
         'openNonWhiteListedRandomNoLocation'
     );
@@ -759,14 +759,14 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'http://google.co.uk',
         function () {
-            doopen('https://google.co.uk', 'random_string', '', 1);
+            doOpen('https://google.co.uk', 'random_string', '', 1);
         },
         'openRedirect301'
     );
     createActionButton(
         'http://goo.gl/pUFqg',
         function () {
-            doopen('https://goo.gl/pUFqg', 'random_string', '', 2);
+            doOpen('https://goo.gl/pUFqg', 'random_string', '', 2);
         },
         'openRedirect302'
     );
@@ -775,7 +775,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'Remote URL',
         function () {
-            doopen('https://www.stluciadance.com/prospectus_file/sample.pdf');
+            doOpen('https://www.stluciadance.com/prospectus_file/sample.pdf');
         },
         'openPDF'
     );
@@ -798,7 +798,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'Invalid Host',
         function () {
-            doopen('https://www.inv;alid.com/', '_blank');
+            doOpen('https://www.inv;alid.com/', '_blank');
         },
         'openInvalidHost'
     );
@@ -974,21 +974,21 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton(
         'no hardwareback (defaults to yes)',
         function () {
-            doopen('https://cordova.apache.org', '_blank');
+            doOpen('https://cordova.apache.org', '_blank');
         },
         'openHardwareBackDefault'
     );
     createActionButton(
         'hardwareback=yes',
         function () {
-            doopen('https://cordova.apache.org', '_blank', 'hardwareback=yes');
+            doOpen('https://cordova.apache.org', '_blank', 'hardwareback=yes');
         },
         'openHardwareBackYes'
     );
     createActionButton(
         'hardwareback=no',
         function () {
-            doopen('https://cordova.apache.org', '_blank', 'hardwareback=no');
+            doOpen('https://cordova.apache.org', '_blank', 'hardwareback=no');
         },
         'openHardwareBackNo'
     );


### PR DESCRIPTION
new cordova apps don't allow http connections by default, so the examples will not work, also it's recommended to use https, so changed the README examples and tests to use https urls.