### PR TITLE
Android: add try catch around dialog.dismiss() to prevent crashes

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -533,7 +533,11 @@ public class InAppBrowser extends CordovaPlugin {
                     // NB: wait for about:blank before dismissing
                     public void onPageFinished(WebView view, String url) {
                         if (dialog != null && !cordova.getActivity().isFinishing()) {
-                            dialog.dismiss();
+                            try {
+                                dialog.dismiss();
+                            } catch(IllegalArgumentException e) {
+                                LOG.e(LOG_TAG, "Caught exception when trying to close IAB dialog: " + e);
+                            }
                             dialog = null;
                         }
                     }


### PR DESCRIPTION
### Platforms affected
many different Android platforms out in the field

### Motivation and Context
Resolves https://github.com/apache/cordova-plugin-inappbrowser/issues/470
Resolves https://github.com/apache/cordova-plugin-inappbrowser/issues/893
Resolves https://github.com/apache/cordova-plugin-inappbrowser/issues/1007
Resolves https://github.com/apache/cordova-plugin-inappbrowser/issues/384

### Description
just adds a try catch block

### Testing
We tested the change out in the field in a productive environment on 100+ different Android devices

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
