### PR TITLE
feat(android): Download event

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
   - __exit__: event fires when the `InAppBrowser` window is closed.
   - __beforeload__: event fires when the `InAppBrowser` decides whether to load an URL or not (only with option `beforeload` set).
   - __message__: event fires when the `InAppBrowser` receives a message posted from the page loaded inside the `InAppBrowser` Webview.
-  - __download__: event fires when the `InAppBrowser` loads a URL that leads in downloading of a file.
+  - __download__: _(Android Only)_ event fires when the `InAppBrowser` loads a URL that leads in downloading of a file.
 
 - __callback__: the function that executes when the event fires. The function is passed an `InAppBrowserEvent` object as a parameter.
 
@@ -336,15 +336,15 @@ Whenever the InAppBrowser receives or locates to a url which leads in downloadin
 ```
 
 function downloadListener(params){
-var url = params.url;
-var mimetype = params.mimetype;
+    var url = params.url;
+    var mimetype = params.mimetype;
 
-var xhr = new XMLHttpRequest();
-xhr.open("GET", params.url);
-xhr.onload = function() {
-    var content = xhr.responseText;
-};
-xhr.send();
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", params.url);
+    xhr.onload = function() {
+        var content = xhr.responseText;
+    };
+    xhr.send();
 
 }
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
   - __exit__: event fires when the `InAppBrowser` window is closed.
   - __beforeload__: event fires when the `InAppBrowser` decides whether to load an URL or not (only with option `beforeload` set).
   - __message__: event fires when the `InAppBrowser` receives a message posted from the page loaded inside the `InAppBrowser` Webview.
+  - __download__: event fires when the `InAppBrowser` loads a URL that leads in downloading of a file.
 
 - __callback__: the function that executes when the event fires. The function is passed an `InAppBrowserEvent` object as a parameter.
 
@@ -321,19 +322,42 @@ function messageCallBack(params){
 }
 
 ```
+#### Download event Example
+
+Whenever the InAppBrowser receives or locates to a url which leads in downloading a file, the callback assigned to the "download" event is called. The parameter passed to this callback is an object with the the following properties
+
+- **type** _it contains the String value "download" always_
+- **url** _The url that leaded to the downloading of file. Basically, the download link of file_
+- **userAgent** _User Agent of the webview_
+- **contentDisposition** _If the url contains "content-disposition" header, then this property holds the value of that field else this field is empty_
+- **contentLength** _If the link of the file allows to obtain file size then this property holds the file size else it contains int value 0_
+- **mimetype** _The MIME type of the file_
+
+```
+
+function downloadListener(params){
+var url = params.url;
+var mimetype = params.mimetype;
+
+var xhr = new XMLHttpRequest();
+xhr.open("GET", params.url);
+xhr.onload = function() {
+    var content = xhr.responseText;
+};
+xhr.send();
+
+}
+
+```
+
 
 ### InAppBrowserEvent Properties
 
 - __type__: the eventname, either `loadstart`, `loadstop`, `loaderror`, `message` or `exit`. _(String)_
-
 - __url__: the URL that was loaded. _(String)_
-
 - __code__: the error code, only in the case of `loaderror`. _(Number)_
-
 - __message__: the error message, only in the case of `loaderror`. _(String)_
-
 - __data__: the message contents , only in the case of `message`. A stringified JSON object. _(String)_
-
 
 ### Supported Platforms
 
@@ -371,6 +395,7 @@ function messageCallBack(params){
   - __loaderror__: event fires when the `InAppBrowser` encounters an error loading a URL.
   - __exit__: event fires when the `InAppBrowser` window is closed.
   - __message__: event fires when the `InAppBrowser` receives a message posted from the page loaded inside the `InAppBrowser` Webview.
+  - __download__: _(Android only)_ event fires when the `InAppBrowser` loads a URL that leads in downloading of a file.
 
 - __callback__: the function to execute when the event fires.
 The function is passed an `InAppBrowserEvent` object.

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1093,7 +1093,7 @@ public class InAppBrowser extends CordovaPlugin {
     private void sendUpdate(JSONObject obj, boolean keepCallback, PluginResult.Status status) {
         if (callbackContext != null) {
             PluginResult result = new PluginResult(status, obj);
-            result.setKeepCallback(keepCallback);                                
+            result.setKeepCallback(keepCallback);
             callbackContext.sendPluginResult(result);
             if (!keepCallback) {
                 callbackContext = null;

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -338,7 +338,6 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
-
         else {
             return false;
         }
@@ -917,10 +916,8 @@ public class InAppBrowser extends CordovaPlugin {
                 View footerClose = createCloseButton(7);
                 footer.addView(footerClose);
 
-
                 // WebView
                 inAppWebView = new WebView(cordova.getActivity());
-
                 inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
                 inAppWebView.setId(Integer.valueOf(6));
                 // File Chooser Implemented ChromeClient
@@ -1096,8 +1093,7 @@ public class InAppBrowser extends CordovaPlugin {
     private void sendUpdate(JSONObject obj, boolean keepCallback, PluginResult.Status status) {
         if (callbackContext != null) {
             PluginResult result = new PluginResult(status, obj);
-            result.setKeepCallback(keepCallback);
-                                
+            result.setKeepCallback(keepCallback);                                
             callbackContext.sendPluginResult(result);
             if (!keepCallback) {
                 callbackContext = null;

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -54,6 +54,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.DownloadListener;
 import android.webkit.WebViewClient;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -97,6 +98,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String LOAD_START_EVENT = "loadstart";
     private static final String LOAD_STOP_EVENT = "loadstop";
     private static final String LOAD_ERROR_EVENT = "loaderror";
+    private static final String DOWNLOAD_EVENT = "download";
     private static final String MESSAGE_EVENT = "message";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
@@ -272,6 +274,7 @@ public class InAppBrowser extends CordovaPlugin {
                         ((InAppBrowserClient)inAppWebView.getWebViewClient()).waitForBeforeload = false;
                     }
                     inAppWebView.loadUrl(url);
+
                 }
             });
         }
@@ -335,6 +338,7 @@ public class InAppBrowser extends CordovaPlugin {
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
         }
+
         else {
             return false;
         }
@@ -916,6 +920,7 @@ public class InAppBrowser extends CordovaPlugin {
 
                 // WebView
                 inAppWebView = new WebView(cordova.getActivity());
+
                 inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
                 inAppWebView.setId(Integer.valueOf(6));
                 // File Chooser Implemented ChromeClient
@@ -946,6 +951,30 @@ public class InAppBrowser extends CordovaPlugin {
                 settings.setJavaScriptCanOpenWindowsAutomatically(true);
                 settings.setBuiltInZoomControls(showZoomControls);
                 settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
+                
+                // download event
+                
+                inAppWebView.setDownloadListener(
+                    new DownloadListener(){
+                        public void onDownloadStart(
+                                String url, String userAgent, String contentDisposition, String mimetype, long contentLength
+                        ){
+                            try{
+                                JSONObject succObj = new JSONObject();
+                                succObj.put("type", DOWNLOAD_EVENT);
+                                succObj.put("url",url);
+                                succObj.put("userAgent",userAgent);
+                                succObj.put("contentDisposition",contentDisposition);
+                                succObj.put("mimetype",mimetype);
+                                succObj.put("contentLength",contentLength);
+                                sendUpdate(succObj, true);
+                            }
+                            catch(Exception e){
+                                LOG.e(LOG_TAG,e.getMessage());
+                            }
+                        }
+                    }
+                );        
 
                 // Add postMessage interface
                 class JsObject {
@@ -1068,6 +1097,7 @@ public class InAppBrowser extends CordovaPlugin {
         if (callbackContext != null) {
             PluginResult result = new PluginResult(status, obj);
             result.setKeepCallback(keepCallback);
+                                
             callbackContext.sendPluginResult(result);
             if (!keepCallback) {
                 callbackContext = null;

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -33,7 +33,8 @@
             loaderror: channel.create('loaderror'),
             exit: channel.create('exit'),
             customscheme: channel.create('customscheme'),
-            message: channel.create('message')
+            message: channel.create('message'),
+            download: channel.create('download')
         };
     }
 
@@ -89,6 +90,10 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
+        },
+
+        addDownloadListener: function (success, error) {
+            exec(success, error, 'InAppBrowser', 'downloadListener');
         }
     };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Adds download event
Rebase of version of https://github.com/apache/cordova-plugin-inappbrowser/pull/743
closes https://github.com/apache/cordova-plugin-inappbrowser/pull/743
closes #311 

This PR fixes a merge conflict that the original PR had, as well as lint issues.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`
Ran cordova-paramedic manually for android API 33.
Ran a manual test and observed the download event coming through for download links.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
