### PR TITLE
feat: iOS - add first request headers and cookies as options

### DIFF
--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -17,7 +17,6 @@
  under the License.
  */
 
-
 @interface CDVInAppBrowserOptions : NSObject {}
 
 @property (nonatomic, assign) BOOL location;
@@ -44,6 +43,13 @@
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL disallowoverscroll;
 @property (nonatomic, copy) NSString* beforeload;
+
+@property (nonatomic, copy) NSDictionary* headers;
+
+/**
+ Key is the cookie name, value is a Set-Cookie HTTP header string representation.
+ */
+@property (nonatomic, copy) NSDictionary* cookies;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -70,7 +70,7 @@
 @property (nonatomic) NSURL* currentURL;
 
 - (void)close;
-- (void)navigateTo:(NSURL*)url;
+- (void)navigateTo:(NSURL*)url options:(CDVInAppBrowserOptions*)options;
 - (void)showLocationBar:(BOOL)show;
 - (void)showToolBar:(BOOL)show : (NSString *) toolbarPosition;
 - (void)setCloseButtonTitle:(NSString*)title : (NSString*) colorString : (int) buttonIndex;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -199,6 +199,47 @@ static CDVWKInAppBrowser* instance = nil;
             NSLog(@"clearsessioncache not available below iOS 11.0");
         }
     }
+    
+    if (browserOptions.cookies.count > 0) {
+                
+        bool isAtLeastiOS11 = false;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+        if (@available(iOS 11.0, *)) {
+            isAtLeastiOS11 = true;
+        }
+#endif
+            
+        if(isAtLeastiOS11){
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+            
+            // Set all cookies
+            WKHTTPCookieStore* cookieStore = dataStore.httpCookieStore;
+            for(NSString* key in browserOptions.cookies){
+                
+                NSURL* url = [NSURL URLWithString:key];
+                if(!url){
+                    NSLog(@"Cookie key is not a proper NSURL!");
+                    continue;
+                }
+                
+                NSArray<NSHTTPCookie*> *cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:@{ @"Set-Cookie" : browserOptions.cookies[key] } forURL:url];
+
+                if(cookies.count == 0) {
+                    NSLog(@"No cookies to process!");
+                }
+                
+                for(NSHTTPCookie* cookie in cookies){
+                    [cookieStore setCookie:cookie completionHandler:nil];
+                }
+                
+            }
+            
+#endif
+        }else{
+            NSLog(@"Cookies set is only available for iOS 11+!");
+        }
+        
+    }
 
     if (self.inAppBrowserViewController == nil) {
         self.inAppBrowserViewController = [[CDVWKInAppBrowserViewController alloc] initWithBrowserOptions: browserOptions andSettings:self.commandDelegate.settings];
@@ -258,7 +299,7 @@ static CDVWKInAppBrowser* instance = nil;
     }
     _waitForBeforeload = ![_beforeload isEqualToString:@""];
     
-    [self.inAppBrowserViewController navigateTo:url];
+    [self.inAppBrowserViewController navigateTo:url options:browserOptions];
     if (!browserOptions.hidden) {
         [self show:nil withNoAnimate:browserOptions.hidden];
     }
@@ -385,7 +426,7 @@ static CDVWKInAppBrowser* instance = nil;
     NSURL* url = [NSURL URLWithString:urlStr];
     //_beforeload = @"";
     _waitForBeforeload = NO;
-    [self.inAppBrowserViewController navigateTo:url];
+    [self.inAppBrowserViewController navigateTo:url options:nil];
 }
 
 // This is a helper method for the inject{Script|Style}{Code|File} API calls, which
@@ -1121,12 +1162,18 @@ BOOL isExiting = FALSE;
     });
 }
 
-- (void)navigateTo:(NSURL*)url
+- (void)navigateTo:(NSURL*)url options:(CDVInAppBrowserOptions*)options
 {
+    NSLog(@"options headers: %@", options.headers);
     if ([url.scheme isEqualToString:@"file"]) {
         [self.webView loadFileURL:url allowingReadAccessToURL:url];
     } else {
-        NSURLRequest* request = [NSURLRequest requestWithURL:url];
+        NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url];
+        for(NSString* key in options.headers) {
+            NSString* value = options.headers[key];
+            [request setValue:value forHTTPHeaderField:key];
+        }
+        NSLog(@"request headers: %@", request.allHTTPHeaderFields);
         [self.webView loadRequest:request];
     }
 }


### PR DESCRIPTION

### Platforms affected
- iOS
- Android (WIP)

### Motivation and Context
It's currently not possible to set cookies and request headers when opening the IAB.

### Description
I'm adding two new options:
- headers
  - key/value map json serialized and base64 encoded
- cookies
  - key/value map json serialized and base64 encoded
  - key is the cookie URL
  - value is the json serialized and base64 encoded header Set-Cookie string

### Limitations

- iOS Cookies are set only if iOS11+

### Testing

From JS side open the IAB with following options:

``` 
const headers = {
  Authorization: `Bearer exampleAccessToken`,
};
const headersString = JSON.stringify(headers);
//Needed because JS->Native parameters serialization uses = to key/value separator
const headersBase64 = btoa(headersString).replaceAll('=', '@');

const cookieOption: CookieSerializeOptions = {
        domain: 'www.mydomain.com',
        secure: true,
        path: '/',
        sameSite: 'strict',
      };

const serializedCookie = cookie.serialize(
        'TEST_NAME',
        'TEST_VALUE',
        cookieOption,
      );
const cookies = {
        ['https://www.mydomain.com']: serializedCookie,
      };
const cookiesString = JSON.stringify(cookies);
//Needed because JS->Native parameters serialization uses = to key/value separator
const cookiesBase64 = btoa(cookiesString).replaceAll('=', '@');

const options = {
  cookies: cookiesBase64,
  headers: headersBase64,
}
if (options && typeof options !== 'string') {
        options = Object.keys(options)
          .map((key: string) => `${key}=${(options as InAppBrowserOptions)[key]}`)
          .join(',');
      }

var ref = cordova.InAppBrowser.open('https://apache.org', '_blank', options);
```



### Checklist

- [?] I've run the tests to see all new and existing tests pass ()
- [?] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
