### PR TITLE
fix(ios): Remove deprecation warnings and old code

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -37,11 +37,6 @@
 
 #pragma mark CDVWKInAppBrowser
 
-@interface CDVWKInAppBrowser () {
-    NSInteger _previousStatusBarStyle;
-}
-@end
-
 @implementation CDVWKInAppBrowser
 
 static CDVWKInAppBrowser* instance = nil;
@@ -53,7 +48,6 @@ static CDVWKInAppBrowser* instance = nil;
 - (void)pluginInitialize
 {
     instance = self;
-    _previousStatusBarStyle = -1;
     _callbackIdPattern = nil;
     _beforeload = @"";
     _waitForBeforeload = NO;
@@ -236,14 +230,6 @@ static CDVWKInAppBrowser* instance = nil;
         NSLog(@"Tried to show IAB after it was closed.");
         return;
     }
-    if (_previousStatusBarStyle != -1) {
-        NSLog(@"Tried to show IAB while already shown");
-        return;
-    }
-    
-    if(!initHidden){
-        _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
-    }
     
     __block CDVInAppBrowserNavigationController* nav = [[CDVInAppBrowserNavigationController alloc]
                                                         initWithRootViewController:self.inAppBrowserViewController];
@@ -291,17 +277,10 @@ static CDVWKInAppBrowser* instance = nil;
         
         
     }
-    if (_previousStatusBarStyle == -1) {
-        NSLog(@"Tried to hide IAB while already hidden");
-        return;
-    }
-    
-    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
     
     // Run later to avoid the "took a long time" log message.
     dispatch_async(dispatch_get_main_queue(), ^{
         if (self.inAppBrowserViewController != nil) {
-            self->_previousStatusBarStyle = -1;
             [self.inAppBrowserViewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         }
     });
@@ -640,15 +619,6 @@ static CDVWKInAppBrowser* instance = nil;
     // Based on https://stackoverflow.com/questions/4544489/how-to-remove-a-uiwindow
     self->tmpWindow.hidden = YES;
     self->tmpWindow = nil;
-
-    if (_previousStatusBarStyle != -1) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
-#pragma clang diagnostic pop
-    }
-
-    _previousStatusBarStyle = -1; // this value was reset before reapplying it. caused statusbar to stay black on ios7
 }
 
 @end //CDVWKInAppBrowser


### PR DESCRIPTION
The plugin requires cordova-ios 6.0.0 or newer, which requires iOS 11, so some old code can be removed.

Removed the code that restores the status bar style since the code that sets the style was removed here https://github.com/apache/cordova-plugin-inappbrowser/pull/656
So now it should always use the style based on the view controller configuration.