### PR TITLE
fix(iOS): IAB not showing up in apps using UIScenes

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -246,11 +246,20 @@ static CDVWKInAppBrowser* instance = nil;
             float osVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf->tmpWindow) {
-                CGRect frame = [[UIScreen mainScreen] bounds];
-                if(initHidden && osVersion < 11){
-                   frame.origin.x = -10000;
+                if (@available(iOS 13.0, *)) {
+                    UIWindowScene *scene = strongSelf.viewController.view.window.windowScene;
+                    if (scene) {
+                        strongSelf->tmpWindow = [[UIWindow alloc] initWithWindowScene:scene];
+                    }
                 }
-                strongSelf->tmpWindow = [[UIWindow alloc] initWithFrame:frame];
+
+                if (!strongSelf->tmpWindow) {
+                    CGRect frame = [[UIScreen mainScreen] bounds];
+                    if(initHidden && osVersion < 11){
+                       frame.origin.x = -10000;
+                    }
+                    strongSelf->tmpWindow = [[UIWindow alloc] initWithFrame:frame];
+                }
             }
             UIViewController *tmpController = [[UIViewController alloc] init];
             [strongSelf->tmpWindow setRootViewController:tmpController];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a Cordova app uses the UIScene APIs introduced in iOS 13, the temporary window created for the IAB ViewController is not associated with that scene and does not appear on screen.


### Description
<!-- Describe your changes in detail -->
On iOS 13 and newer, check if the CDVViewController's owner window has an associated scene. If yes, use that when constructing the temporary UIWindow for the IAB view.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested manually using mobilespec in a simulator with cordova-ios @ 7.1.1.
Tested manually using mobilespec in a simulator with cordova-ios @ 8.0.0-dev.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
