### PR TITLE
chore(ios)!: Remove unused private method

### DIFF
--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -45,7 +45,6 @@ typedef NSDictionary CDVSettingsDictionary;
 @property (nonatomic, retain) CDVWKInAppBrowser *instance;
 @property (nonatomic, retain) CDVWKInAppBrowserViewController *inAppBrowserViewController;
 @property (nonatomic, copy) NSString *callbackId;
-@property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 
 + (id) getInstance;
 - (void)open:(CDVInvokedUrlCommand *)command;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -414,23 +414,6 @@ static CDVWKInAppBrowser *instance = nil;
     [self injectDeferredObject:[command argumentAtIndex:0] withWrapper:jsWrapper];
 }
 
-- (BOOL)isValidCallbackId:(NSString *)callbackId
-{
-    NSError *err = nil;
-    // Initialize on first use
-    if (self.callbackIdPattern == nil) {
-        self.callbackIdPattern = [NSRegularExpression regularExpressionWithPattern:@"^InAppBrowser[0-9]{1,10}$" options:0 error:&err];
-        if (err != nil) {
-            // Couldn't initialize Regex; No is safer than Yes.
-            return NO;
-        }
-    }
-    if ([self.callbackIdPattern firstMatchInString:callbackId options:0 range:NSMakeRange(0, [callbackId length])]) {
-        return YES;
-    }
-    return NO;
-}
-
 /**
  * The message handler bridge provided for the InAppBrowser is capable of executing any oustanding callback belonging
  * to the InAppBrowser plugin. Care has been taken that other callbacks cannot be triggered, and that no

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -44,7 +44,6 @@ static CDVWKInAppBrowser *instance = nil;
 - (void)pluginInitialize
 {
     instance = self;
-    _callbackIdPattern = nil;
     _beforeload = @"";
     _waitForBeforeload = NO;
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`isValidCallbackId` is defined but it seems there are no references.

### Description
<!-- Describe your changes in detail -->

Remove `isValidCallbackId`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Run on iOS simulator.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
