### PR TITLE
fix(ios): constraint warnings in iOS 18 and older

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -728,8 +728,12 @@ BOOL isExiting = NO;
     // We add our own constraints, they should not be determined from the frame.
     self.webView.translatesAutoresizingMaskIntoConstraints = NO;
 
-    // Toolbar init without frame
-    self.toolbar = [[UIToolbar alloc] init];
+    // Toolbar init with a symbolic frame
+    // On iOS 18 and older contraint warnings are logged when a zero frame is set and toolbar items
+    // are added.
+    // This a known iOS Bug, see: https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue
+    // To avoid this a symbolic frame is set, which have no impact, because auto layout is used
+    self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0.0, 0.0, 100.0, 100.0)];
     self.toolbar.alpha = 1.000;
     self.toolbar.barStyle = UIBarStyleBlack;
     self.toolbar.clearsContextBeforeDrawing = NO;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -760,7 +760,10 @@ BOOL isExiting = NO;
     self.toolbarBackground.backgroundColor = toolbarBackgroundColor;
     [self.view addSubview:self.toolbarBackground];
     
-    self.toolbar = [UIToolbar new];
+    // NOTE: Initializing UIToolbar with initWithFrame: instead of `new` prevents
+    // constraint warnings on iOS 18 and older, which has no impact, since auto
+    // layout is used.
+    self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0.0, 0.0, 100.0, 100.0)];
     // Remove the toolbar background on iOS 18 and older
     if (@available(iOS 26.0, *)) {
         // Don't do anything on iOS 26 and newer, there is no background by default


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- On iOS 18 and older constraint warnings are logged when a zero frame for the toolbar is set and items are added. This a known iOS Bug, see: https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue. To avoid this a symbolic frame is set, which have no impact, because auto layout is used.

### Constraint warnings without PR changes

```log
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002131540 h=--& v=--& _UIToolbarContentView:0x106a07b90.width == 0   (active)>",
    "<NSLayoutConstraint:0x600002125180 H:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021262b0 H:[_UIButtonBarStackView:0x106a084c0]-(0)-|   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x600002133d90 'TB_Leading_Leading' H:|-(8)-[_UIModernBarButton:0x106b213e0]   (active, names: '|':_UIButtonBarButton:0x106b20e60 )>",
    "<NSLayoutConstraint:0x600002133de0 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106b213e0]-(8)-|   (active, names: '|':_UIButtonBarButton:0x106b20e60 )>",
    "<NSLayoutConstraint:0x600002131db0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.leading == _UIButtonBarButton:0x106a08df0.leading   (active)>",
    "<NSLayoutConstraint:0x6000021315e0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.trailing == _UIButtonBarButton:0x106b2d9a0.trailing   (active)>",
    "<NSLayoutConstraint:0x6000021318b0 'UISV-spacing' H:[_UIButtonBarButton:0x106a08df0]-(0)-[UIView:0x106b20ce0]   (active)>",
    "<NSLayoutConstraint:0x600002131900 'UISV-spacing' H:[UIView:0x106b20ce0]-(0)-[_UIButtonBarButton:0x106b20e60]   (active)>",
    "<NSLayoutConstraint:0x600002131c70 'UISV-spacing' H:[_UIButtonBarButton:0x106b20e60]-(0)-[UIView:0x106b2cf70]   (active)>",
    "<NSLayoutConstraint:0x600002132a30 'UISV-spacing' H:[UIView:0x106b2cf70]-(0)-[_UIButtonBarButton:0x106b2d9a0]   (active)>",
    "<NSLayoutConstraint:0x600002124870 'UIView-leftMargin-guide-constraint' H:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002124690 'UIView-rightMargin-guide-constraint' H:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|(LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600002133de0 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106b213e0]-(8)-|   (active, names: '|':_UIButtonBarButton:0x106b20e60 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002131540 h=--& v=--& _UIToolbarContentView:0x106a07b90.width == 0   (active)>",
    "<NSLayoutConstraint:0x600002125180 H:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021262b0 H:[_UIButtonBarStackView:0x106a084c0]-(0)-|   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x600002133200 'TB_Leading_Leading' H:|-(0)-[_UIModernBarButton:0x106919a40]   (active, names: '|':_UIButtonBarButton:0x106a08df0 )>",
    "<NSLayoutConstraint:0x600002133250 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106919a40]-(8)-|   (active, names: '|':_UIButtonBarButton:0x106a08df0 )>",
    "<NSLayoutConstraint:0x600002131db0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.leading == _UIButtonBarButton:0x106a08df0.leading   (active)>",
    "<NSLayoutConstraint:0x6000021315e0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.trailing == _UIButtonBarButton:0x106b2d9a0.trailing   (active)>",
    "<NSLayoutConstraint:0x6000021318b0 'UISV-spacing' H:[_UIButtonBarButton:0x106a08df0]-(0)-[UIView:0x106b20ce0]   (active)>",
    "<NSLayoutConstraint:0x600002131900 'UISV-spacing' H:[UIView:0x106b20ce0]-(0)-[_UIButtonBarButton:0x106b20e60]   (active)>",
    "<NSLayoutConstraint:0x600002131c70 'UISV-spacing' H:[_UIButtonBarButton:0x106b20e60]-(0)-[UIView:0x106b2cf70]   (active)>",
    "<NSLayoutConstraint:0x600002132a30 'UISV-spacing' H:[UIView:0x106b2cf70]-(0)-[_UIButtonBarButton:0x106b2d9a0]   (active)>",
    "<NSLayoutConstraint:0x600002124870 'UIView-leftMargin-guide-constraint' H:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002124690 'UIView-rightMargin-guide-constraint' H:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|(LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600002133250 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106919a40]-(8)-|   (active, names: '|':_UIButtonBarButton:0x106a08df0 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002131540 h=--& v=--& _UIToolbarContentView:0x106a07b90.width == 0   (active)>",
    "<NSLayoutConstraint:0x600002125180 H:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021262b0 H:[_UIButtonBarStackView:0x106a084c0]-(0)-|   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x600002133660 'TB_Leading_Leading' H:|-(8)-[_UIModernBarButton:0x106b2dd90]   (active, names: '|':_UIButtonBarButton:0x106b2d9a0 )>",
    "<NSLayoutConstraint:0x6000021336b0 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106b2dd90]-(0)-|   (active, names: '|':_UIButtonBarButton:0x106b2d9a0 )>",
    "<NSLayoutConstraint:0x600002131db0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.leading == _UIButtonBarButton:0x106a08df0.leading   (active)>",
    "<NSLayoutConstraint:0x6000021315e0 'UISV-canvas-connection' UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.trailing == _UIButtonBarButton:0x106b2d9a0.trailing   (active)>",
    "<NSLayoutConstraint:0x6000021318b0 'UISV-spacing' H:[_UIButtonBarButton:0x106a08df0]-(0)-[UIView:0x106b20ce0]   (active)>",
    "<NSLayoutConstraint:0x600002131900 'UISV-spacing' H:[UIView:0x106b20ce0]-(0)-[_UIButtonBarButton:0x106b20e60]   (active)>",
    "<NSLayoutConstraint:0x600002131c70 'UISV-spacing' H:[_UIButtonBarButton:0x106b20e60]-(0)-[UIView:0x106b2cf70]   (active)>",
    "<NSLayoutConstraint:0x600002132a30 'UISV-spacing' H:[UIView:0x106b2cf70]-(0)-[_UIButtonBarButton:0x106b2d9a0]   (active)>",
    "<NSLayoutConstraint:0x600002124870 'UIView-leftMargin-guide-constraint' H:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'](LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002124690 'UIView-rightMargin-guide-constraint' H:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|(LTR)   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x6000021336b0 'TB_Trailing_Trailing' H:[_UIModernBarButton:0x106b2dd90]-(0)-|   (active, names: '|':_UIButtonBarButton:0x106b2d9a0 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002132710 h=--& v=--& _UIToolbarContentView:0x106a07b90.height == 0   (active)>",
    "<NSLayoutConstraint:0x6000021256d0 V:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021251d0 _UIButtonBarStackView:0x106a084c0.bottom == _UIToolbarContentView:0x106a07b90.bottom   (active)>",
    "<NSLayoutConstraint:0x600002131310 UIButtonLabel:0x106b1ef40.centerY == _UIModernBarButton:0x106919a40.centerY + 1.5   (active)>",
    "<NSLayoutConstraint:0x600002132f30 'TB_Baseline_Baseline' _UIModernBarButton:0x106919a40.lastBaseline == UILayoutGuide:0x600003b1bb80'UIViewLayoutMarginsGuide'.bottom   (active)>",
    "<NSLayoutConstraint:0x600002132f80 'TB_Top_Top' V:|-(>=0)-[_UIModernBarButton:0x106919a40]   (active, names: '|':_UIButtonBarButton:0x106a08df0 )>",
    "<NSLayoutConstraint:0x6000021330c0 'UIButtonBar.maximumAlignmentSize' _UIButtonBarButton:0x106a08df0.height == UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.height   (active)>",
    "<NSLayoutConstraint:0x600002124d70 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002132e90 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b1bb80'UIViewLayoutMarginsGuide']-(11)-|   (active, names: '|':_UIButtonBarButton:0x106a08df0 )>",
    "<NSLayoutConstraint:0x600002124e60 'UIView-topMargin-guide-constraint' V:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600002131310 UIButtonLabel:0x106b1ef40.centerY == _UIModernBarButton:0x106919a40.centerY + 1.5   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002132710 h=--& v=--& _UIToolbarContentView:0x106a07b90.height == 0   (active)>",
    "<NSLayoutConstraint:0x6000021256d0 V:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021251d0 _UIButtonBarStackView:0x106a084c0.bottom == _UIToolbarContentView:0x106a07b90.bottom   (active)>",
    "<NSLayoutConstraint:0x60000210d450 UIButtonLabel:0x106b2d670.centerY == _UIModernBarButton:0x106b213e0.centerY + 1.5   (active)>",
    "<NSLayoutConstraint:0x600002133bb0 'TB_Baseline_Baseline' _UIModernBarButton:0x106b213e0.lastBaseline == UILayoutGuide:0x600003b2c2a0'UIViewLayoutMarginsGuide'.bottom   (active)>",
    "<NSLayoutConstraint:0x600002133c00 'TB_Top_Top' V:|-(>=0)-[_UIModernBarButton:0x106b213e0]   (active, names: '|':_UIButtonBarButton:0x106b20e60 )>",
    "<NSLayoutConstraint:0x600002133890 'UIButtonBar.maximumAlignmentSize' _UIButtonBarButton:0x106b20e60.height == UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.height   (active)>",
    "<NSLayoutConstraint:0x600002124d70 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002133b10 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b2c2a0'UIViewLayoutMarginsGuide']-(11)-|   (active, names: '|':_UIButtonBarButton:0x106b20e60 )>",
    "<NSLayoutConstraint:0x600002124e60 'UIView-topMargin-guide-constraint' V:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000210d450 UIButtonLabel:0x106b2d670.centerY == _UIModernBarButton:0x106b213e0.centerY + 1.5   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x600002132710 h=--& v=--& _UIToolbarContentView:0x106a07b90.height == 0   (active)>",
    "<NSLayoutConstraint:0x6000021256d0 V:|-(0)-[_UIButtonBarStackView:0x106a084c0]   (active, names: '|':_UIToolbarContentView:0x106a07b90 )>",
    "<NSLayoutConstraint:0x6000021251d0 _UIButtonBarStackView:0x106a084c0.bottom == _UIToolbarContentView:0x106a07b90.bottom   (active)>",
    "<NSLayoutConstraint:0x60000210a170 UIButtonLabel:0x106b2e2f0.centerY == _UIModernBarButton:0x106b2dd90.centerY + 1.5   (active)>",
    "<NSLayoutConstraint:0x600002132170 'TB_Baseline_Baseline' _UIModernBarButton:0x106b2dd90.lastBaseline == UILayoutGuide:0x600003b2c380'UIViewLayoutMarginsGuide'.bottom   (active)>",
    "<NSLayoutConstraint:0x600002132210 'TB_Top_Top' V:|-(>=0)-[_UIModernBarButton:0x106b2dd90]   (active, names: '|':_UIButtonBarButton:0x106b2d9a0 )>",
    "<NSLayoutConstraint:0x600002131cc0 'UIButtonBar.maximumAlignmentSize' _UIButtonBarButton:0x106b2d9a0.height == UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide'.height   (active)>",
    "<NSLayoutConstraint:0x600002124d70 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']-(0)-|   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>",
    "<NSLayoutConstraint:0x600002131c20 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x600003b2c380'UIViewLayoutMarginsGuide']-(11)-|   (active, names: '|':_UIButtonBarButton:0x106b2d9a0 )>",
    "<NSLayoutConstraint:0x600002124e60 'UIView-topMargin-guide-constraint' V:|-(0)-[UILayoutGuide:0x600003b0e760'UIViewLayoutMarginsGuide']   (active, names: '|':_UIButtonBarStackView:0x106a084c0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000210a170 UIButtonLabel:0x106b2e2f0.centerY == _UIModernBarButton:0x106b2dd90.centerY + 1.5   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
```

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Test on iOS 18.5 and iOS 26.4 simulator

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
