### PR TITLE
doc(ios): constraint warnings on iOS 26 and using `initWithBarButtonSystemItem`

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -810,8 +810,8 @@ BOOL isExiting = NO;
     // We add our own constraints, they should not be determined from the frame.
     self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
 
-    // On iOS 26 adding `UIBarButtonItem` with `initWithBarButtonSystemItem` gives constraint warnings here,
-    // which seems to be an UIKit bug. See: https://stackoverflow.com/questions/79767518/simple-toolbar-population-causes-auto-layout-conflict
+    // NOTE: On iOS 26 using `UIBarButtonItem initWithBarButtonSystemItem:` gives constraint warnings,
+    // which is a known UIKit bug. This cannot be fixed.
     self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
     self.closeButton.enabled = YES;
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -794,6 +794,8 @@ BOOL isExiting = NO;
     // We add our own constraints, they should not be determined from the frame.
     self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
 
+    // On iOS 26 adding `UIBarButtonItem` with `initWithBarButtonSystemItem` gives constraint warnings here,
+    // which seems to be an UIKit bug. See: https://stackoverflow.com/questions/79767518/simple-toolbar-population-causes-auto-layout-conflict
     self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
     self.closeButton.enabled = YES;
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -811,7 +811,7 @@ BOOL isExiting = NO;
     self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
 
     // NOTE: On iOS 26 using `UIBarButtonItem initWithBarButtonSystemItem:` gives constraint warnings,
-    // which is a known UIKit bug. This cannot be fixed.
+    // which is a known UIKit bug.
     self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
     self.closeButton.enabled = YES;
 


### PR DESCRIPTION
- Add a note, that using `initWithBarButtonSystemItem` gives constraint warnings on iOS 26, which is due to a iOS bug

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
