### PR TITLE
fix(ios): add custom toolbar background

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ instance, or the system browser.
     - __navigationbuttoncolor__:  set as a valid hex color string, for example: `#00ff00`, to change from the default color. Only applicable if navigation buttons are visible.
     - __toolbar__:  set to `yes` or `no` to turn the toolbar on or off for the InAppBrowser (defaults to `yes`)
     - __toolbarcolor__: set as a valid hex color string, for example: `#00ff00`, to change from the default color of the toolbar. Only applicable if toolbar is not disabled.
-    - __toolbartranslucent__:  set to `yes` or `no` to make the toolbar translucent(semi-transparent)  (defaults to `yes`). Only applicable if toolbar is not disabled.
+    - __toolbartranslucent__:  set to `yes` or `no` to make the toolbar translucent(semi-transparent). Only applicable if toolbar is not disabled. The toolbar is semi-transparent by default.
     - __lefttoright__: Set to `yes` to swap positions of the navigation buttons and the close button. Specifically, close button goes to the right and navigation buttons to the left.
     - __enableViewportScale__:  Set to `yes` or `no` to prevent viewport scaling through a meta tag (defaults to `no`).
     - __mediaPlaybackRequiresUserAction__: Set to `yes` to prevent HTML5 audio or video from autoplaying (defaults to `no`).

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -72,6 +72,7 @@ typedef NSDictionary CDVSettingsDictionary;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem *backButton;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem *forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) IBOutlet UIView *toolbarBackground;
 @property (nonatomic, strong) IBOutlet UIToolbar *toolbar;
 @property (nonatomic, strong) IBOutlet CDVWKInAppBrowserUIDelegate *webViewUIDelegate;
 

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -67,6 +67,7 @@ typedef NSDictionary CDVSettingsDictionary;
 @property (nonatomic, strong) IBOutlet WKWebView *webView;
 @property (nonatomic, strong) IBOutlet WKWebViewConfiguration *configuration;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem *closeButton;
+@property (nonatomic, strong) IBOutlet UIView *addressBackgroundView;
 @property (nonatomic, strong) IBOutlet UILabel *addressLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem *backButton;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem *forwardButton;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -38,6 +38,9 @@
 
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
+// Common margin for sub views
+#define    MARGIN 12.0
+
 #pragma mark CDVWKInAppBrowser
 
 @implementation CDVWKInAppBrowser
@@ -751,7 +754,7 @@ BOOL isExiting = NO;
 
     // Background view for address label
     self.addressBackgroundView = [[UIView alloc] init];
-    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
+    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.4];
     self.addressBackgroundView.layer.cornerRadius = 15.0;
     // Don't draw any content that would be outside the view’s rectangular bounds
     self.addressBackgroundView.clipsToBounds = YES;
@@ -909,85 +912,110 @@ BOOL isExiting = NO;
     BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
     BOOL toolbarVisible = _browserOptions.toolbar;
     BOOL addressLabelVisible = _browserOptions.location;
-    const CGFloat addressBackgroundTopBottomMargin = 12.0;
     
     // Center spinner in WebView
     [self.spinner.centerXAnchor constraintEqualToAnchor:self.webView.centerXAnchor].active = YES;
     [self.spinner.centerYAnchor constraintEqualToAnchor:self.webView.centerYAnchor].active = YES;
 
     // Constraints for different cases set by options when Toolbar and/or Address label is visible or not
-    //
-    // Case 1: Toolbar and Address label not visible
-    if (!toolbarVisible && !addressLabelVisible) {
-        // Webview top to top edge
-        [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
-        // WebView bottom to bottom edge
-        [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
-    }
+    // Constraint WebView fullscreen and overlay Toolbar and Address label on it
+    // Webview top to top edge
+    [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
+    // WebView bottom to bottom edge
+    [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 
-    // Case 2: Toolbar visible, Address label not visible
+    // Case 1: Toolbar visible, Address label not visible
     if (toolbarVisible && !addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
             // Toolbar top to safe area top
             [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-            // Webview top to Toolbar bottom
-            [self.webView.topAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor].active = YES;
-            // WebView bottom to bottom edge
-            [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 
             // Toolbar is at bottom (default)
         } else {
-            // WebView top to top edge
-            [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
-            // WebView bottom to Toolbar top
-            [self.webView.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor].active = YES;
             // Toolbar bottom to safe area bottom
             [self.toolbar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
         }
     }
 
-    // Case 3: Toolbar not visible, Address label visible
+    // Case 2: Toolbar not visible, Address label visible
     if (!toolbarVisible && addressLabelVisible) {
-        // Webview top to top edge
-        [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
-        // Address background top to WebView bottom with margin
-        [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
-                                                             constant:addressBackgroundTopBottomMargin].active = YES;
-        // Address background bottom to safe area bottom with margin, margin must be negativ here
-        [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor
-                                                                constant:addressBackgroundTopBottomMargin *-1].active = YES;
+        // Address background bottom to safe area bottom
+        [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
     }
 
-    // Case 4: Toolbar visible and Address label visible
+    // Case 3: Toolbar visible and Address label visible
     if (toolbarVisible && addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
             // Toolbar top to safe area top
             [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-            // Webview top to Toolbar bottom
-            [self.webView.topAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor].active = YES;
-            // Address background top to WebView bottom with margin
-            [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
-                                                                 constant:addressBackgroundTopBottomMargin].active = YES;
-            // Address background bottom to safe area bottom with margin, margin must be negativ here
-            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor
-                                                                    constant:addressBackgroundTopBottomMargin *-1].active = YES;
+            // Address background bottom to safe area bottom
+            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
 
             // Toolbar is at bottom (default)
         } else {
-            // WebView top to top edge
-            [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
-            // Address background top to WebView bottom with margin
-            [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
-                                                                 constant:addressBackgroundTopBottomMargin].active = YES;
             // Address background bottom to Toolbar top with margin, margin must be negativ here
             [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor
-                                                                    constant:addressBackgroundTopBottomMargin *-1].active = YES;
+                                                                    constant:MARGIN*-1].active = YES;
             // Toolbar bottom to safe area bottom
             [self.toolbar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
         }
     }
+}
+
+- (void)viewDidLayoutSubviews
+{
+    // Setting the WebView insets must be done after the sub views are layed out,
+    // so their size are properly set and can be used for the inset calculation
+    [self setWebViewInsets];
+}
+
+/**
+    Sets `contentInset` and `verticalScrollIndicatorInsets` of the WebView for the optional
+    overlayed Toolbar and Address Bar controlled by options,  so the content can always be scrolled in the visible area.
+ */
+- (void)setWebViewInsets
+{
+    // Toolbar and Address label are optional
+    BOOL toolbarVisible = _browserOptions.toolbar;
+    BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    BOOL addressLabelVisible = _browserOptions.location;
+    // Height and width of Toolbar and Address Background, which is needed to calculate the inset of the WebView
+    const CGFloat toolbarHeight = self.toolbar.bounds.size.height;
+    const CGFloat addressBackgroundHeight = self.addressBackgroundView.bounds.size.height;
+    // Insets for the WebView, which gets calcualted
+    CGFloat topInset = 0.0;
+    CGFloat bottomInset = 0.0;
+    
+    if (toolbarVisible) {
+        // Toolbar is at top
+        if (toolbarIsAtTop) {
+            topInset = toolbarHeight;
+
+            // Toolbar is at bottom (default)
+        } else {
+            bottomInset = toolbarHeight;
+        }
+    }
+
+    if (addressLabelVisible) {
+        bottomInset += addressBackgroundHeight;
+        
+        // If the Toolbar is at bottom, the Address Background View is separated to the Toolbar with
+        // a margin, which must also be added to the inset
+        if (toolbarVisible && !toolbarIsAtTop) {
+            bottomInset += MARGIN;
+        }
+    }
+    
+    // Add additional margin to insets, so there is always room between the overlayed views
+    // and the web content, when the start or end is reached
+    if (topInset) topInset += MARGIN;
+    if (bottomInset) bottomInset += MARGIN;
+    
+    self.webView.scrollView.contentInset = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
+    self.webView.scrollView.verticalScrollIndicatorInsets = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
 }
 
 - (void)setWebViewFrame:(CGRect)frame
@@ -1145,7 +1173,6 @@ BOOL isExiting = NO;
     self.addressLabel.text = self.currentURL.absoluteString;
     self.backButton.enabled = theWebView.canGoBack;
     self.forwardButton.enabled = theWebView.canGoForward;
-    theWebView.scrollView.contentInset = UIEdgeInsetsZero;
     [self.spinner stopAnimating];
     [self.navigationDelegate didFinishNavigation:theWebView];
 }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -564,7 +564,7 @@
 
 - (void)didStartProvisionalNavigation:(WKWebView *)theWebView
 {
-    NSLog(@"didStartProvisionalNavigation");
+    // Do nothing here
 }
 
 - (void)didFinishNavigation:(WKWebView *)theWebView
@@ -730,71 +730,56 @@ BOOL isExiting = NO;
 
     // We add our own constraints, they should not be determined from the frame.
     self.webView.translatesAutoresizingMaskIntoConstraints = NO;
-
-    // Toolbar init without frame
-    self.toolbar = [[UIToolbar alloc] init];
-    self.toolbar.alpha = 1.000;
+    
+    self.toolbarBackground = [UIView new];
+    // We add our own constraints, they should not be determined from the frame.
+    self.toolbarBackground.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    // Get toolbar background color by options or set default which is white
+    UIColor *toolbarBackgroundColor = _browserOptions.toolbarcolor ? [self colorFromHexString:_browserOptions.toolbarcolor] : UIColor.whiteColor;
+    
+    // Make toolbar semi-transparent by options, default is YES
+    if (_browserOptions.toolbartranslucent) {
+        // On iOS 18 and older, use a semi-transparent color
+        toolbarBackgroundColor = [toolbarBackgroundColor colorWithAlphaComponent:0.6];
+    }
+    
+    self.toolbarBackground.backgroundColor = toolbarBackgroundColor;
+    [self.view addSubview:self.toolbarBackground];
+    
+    self.toolbar = [UIToolbar new];
+    // Remove default background for toolbar on iOS 18 and older, since we provide our own
+    // backround
+    // Remove background
+    [self.toolbar setBackgroundImage:[UIImage new]
+                  forToolbarPosition:UIToolbarPositionAny
+                          barMetrics:UIBarMetricsDefault];
+    // barStyle has to be set to UIBarStyleBlack, otherwhise there would be a gray line left,
+    // after the background was removed
     self.toolbar.barStyle = UIBarStyleBlack;
-    self.toolbar.clearsContextBeforeDrawing = NO;
-    self.toolbar.clipsToBounds = NO;
-    self.toolbar.contentMode = UIViewContentModeScaleToFill;
-    self.toolbar.hidden = NO;
-    self.toolbar.multipleTouchEnabled = NO;
-    self.toolbar.opaque = NO;
-    self.toolbar.userInteractionEnabled = YES;
-    if (_browserOptions.toolbarcolor != nil) { // Set toolbar color if user sets it in options
-        self.toolbar.barTintColor = [self colorFromHexString:_browserOptions.toolbarcolor];
-    }
-    if (!_browserOptions.toolbartranslucent) { // Set toolbar translucent to no if user sets it in options
-        self.toolbar.translucent = NO;
-    }
-    [self.view addSubview:self.toolbar];
     // We add our own constraints, they should not be determined from the frame.
     self.toolbar.translatesAutoresizingMaskIntoConstraints = NO;
-
+    [self.toolbarBackground addSubview:self.toolbar];
+    
     // Background view for address label
-    self.addressBackgroundView = [[UIView alloc] init];
-    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
+    self.addressBackgroundView = [UIView new];
+    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.6];
     self.addressBackgroundView.layer.cornerRadius = 15.0;
-    // Don't draw any content that would be outside the view’s rectangular bounds
-    self.addressBackgroundView.clipsToBounds = YES;
-    [self.view addSubview:self.addressBackgroundView];
     // We add our own constraints, they should not be determined from the frame.
     self.addressBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.addressBackgroundView];
     
-    self.addressLabel = [[UILabel alloc] init];
-    self.addressLabel.adjustsFontSizeToFitWidth = NO;
-    self.addressLabel.alpha = 1.000;
-    self.addressLabel.backgroundColor = [UIColor clearColor];
-    self.addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
-    self.addressLabel.clearsContextBeforeDrawing = YES;
-    // Don't draw any content that would be outside the view’s rectangular bounds
-    self.addressLabel.clipsToBounds = YES;
-    self.addressLabel.contentMode = UIViewContentModeScaleToFill;
-    self.addressLabel.enabled = YES;
-    self.addressLabel.hidden = NO;
-    self.addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-
-    if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumScaleFactor:")]) {
-        [self.addressLabel setValue:@(10.0/[UIFont labelFontSize]) forKey:@"minimumScaleFactor"];
-    } else if ([self.addressLabel respondsToSelector:NSSelectorFromString(@"setMinimumFontSize:")]) {
-        [self.addressLabel setValue:@(10.0) forKey:@"minimumFontSize"];
-    }
-
-    self.addressLabel.multipleTouchEnabled = NO;
-    self.addressLabel.numberOfLines = 1;
-    self.addressLabel.opaque = NO;
-    self.addressLabel.shadowOffset = CGSizeMake(0.0, -1.0);
+    self.addressLabel = [UILabel new];
     self.addressLabel.text = NSLocalizedString(@"Loading...", nil);
+    self.addressLabel.textColor = UIColor.blackColor;
     self.addressLabel.textAlignment = NSTextAlignmentLeft;
-    self.addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
-    self.addressLabel.userInteractionEnabled = NO;
-    [self.addressBackgroundView addSubview:self.addressLabel];
+    // Truncate at tail of line: "abcd..."
+    self.addressLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     // We add our own constraints, they should not be determined from the frame.
     self.addressLabel.translatesAutoresizingMaskIntoConstraints = NO;
-
+    [self.addressBackgroundView addSubview:self.addressLabel];
+    
     self.spinner = [[UIActivityIndicatorView alloc] initWithFrame:CGRectZero];
-    self.spinner.alpha = 1.000;
     self.spinner.clearsContextBeforeDrawing = NO;
     self.spinner.clipsToBounds = NO;
     self.spinner.contentMode = UIViewContentModeScaleToFill;
@@ -881,12 +866,18 @@ BOOL isExiting = NO;
         [self.webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
     ]];
 
-    // Toolbar horizontal constraints
+    // Toolbar background horizontal constraints
     [NSLayoutConstraint activateConstraints:@[
         // Left
-        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.toolbarBackground.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
         // Right
-        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
+        [self.toolbarBackground.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
+    ]];
+
+    // Constrain Toolbar inside Toolbar background view with padding
+    [NSLayoutConstraint activateConstraints:@[
+        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.leadingAnchor constant:10.0],
+        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.trailingAnchor constant:-10.0]
     ]];
 
     // Address background horizontal constraints with margin
@@ -898,7 +889,7 @@ BOOL isExiting = NO;
         [self.addressBackgroundView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
                                                                   constant:-15.0]
     ]];
-    
+
     // Constrain Address label inside Address background view with padding
     [NSLayoutConstraint activateConstraints:@[
         [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor constant:10.0],
@@ -928,38 +919,67 @@ BOOL isExiting = NO;
     if (toolbarVisible && !addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
-            // Toolbar top to safe area top
-            [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-
+            [NSLayoutConstraint activateConstraints:@[
+                // Toolbar background top to top edge
+                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                // Toolbar background bottom to toolbar bottom with margin
+                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
+                                                                    constant:MARGIN],
+                // Toolbar top to background safe area top
+                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor]
+            ]];
             // Toolbar is at bottom (default)
         } else {
-            // Toolbar bottom to safe area bottom
-            [self.toolbar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+            [NSLayoutConstraint activateConstraints:@[
+                // Toolbar background top to toolbar top with margin, margin must be negative here
+                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.toolbar.topAnchor
+                                                                 constant:MARGIN*-1],
+                // Toolbar background bottom to bottom edge
+                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+                // Toolbar bottom to background safe area bottom
+                [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor]
+            ]];
         }
     }
 
-    // Case 2: Toolbar not visible, Address label visible
+    // Case 2: Toolbar not visible, Address label visible (default)
     if (!toolbarVisible && addressLabelVisible) {
-        // Address background bottom to safe area bottom
-        [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+        [NSLayoutConstraint activateConstraints:@[
+            // Address background bottom to safe area bottom
+            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
+        ]];
     }
 
     // Case 3: Toolbar visible and Address label visible
     if (toolbarVisible && addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
-            // Toolbar top to safe area top
-            [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-            // Address background bottom to safe area bottom
-            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+            [NSLayoutConstraint activateConstraints:@[
+                // Toolbar background top to top edge
+                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                // Toolbar background bottom to Toolbar bottom with margin
+                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
+                                                                    constant:MARGIN],
+                // Toolbar top to backround safe area top
+                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor],
+                // Address background bottom to safe area bottom
+                [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
+            ]];
 
             // Toolbar is at bottom (default)
         } else {
-            // Address background bottom to Toolbar top with margin, margin must be negativ here
-            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor
-                                                                    constant:MARGIN*-1].active = YES;
-            // Toolbar bottom to safe area bottom
-            [self.toolbar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+            [NSLayoutConstraint activateConstraints:@[
+                // Address background bottom to Toolbar Background top with margin, margin must be negative here
+                [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.topAnchor
+                                                                        constant:MARGIN*-1],
+                // Toolbar background top to Toolbar top with margin, margin must be negative here
+                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.toolbar.topAnchor
+                                                                 constant:MARGIN*-1],
+                // Toolbar background bottom to bottom edge
+                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+                // Toolbar bottom to background safe area bottom
+                [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor]
+            ]];
         }
     }
 }
@@ -982,38 +1002,34 @@ BOOL isExiting = NO;
     BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
     BOOL addressLabelVisible = _browserOptions.location;
     // Height and width of Toolbar and Address Background, which is needed to calculate the inset of the WebView
-    const CGFloat toolbarHeight = self.toolbar.bounds.size.height;
+    const CGFloat toolbarBackgroundHeight = self.toolbarBackground.bounds.size.height;
     const CGFloat addressBackgroundHeight = self.addressBackgroundView.bounds.size.height;
     // Insets for the WebView, which gets calcualted
     CGFloat topInset = 0.0;
     CGFloat bottomInset = 0.0;
-    
+
     if (toolbarVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
-            topInset = toolbarHeight;
+            topInset = toolbarBackgroundHeight - self.view.safeAreaInsets.top;
 
             // Toolbar is at bottom (default)
         } else {
-            bottomInset = toolbarHeight;
+            bottomInset = toolbarBackgroundHeight - self.view.safeAreaInsets.bottom;
         }
     }
 
     if (addressLabelVisible) {
-        bottomInset += addressBackgroundHeight;
-        
-        // If the Toolbar is at bottom, the Address Background View is separated to the Toolbar with
-        // a margin, which must also be added to the inset
+        // The scroll inset should have a margin to the address bar
+        bottomInset += addressBackgroundHeight + MARGIN;
+
+        // Add the margin between address bar and toolbar if toolbar is at bottom and visible
         if (toolbarVisible && !toolbarIsAtTop) {
             bottomInset += MARGIN;
         }
     }
-    
-    // Add additional margin to insets, so there is always room between the overlayed views
-    // and the web content, when the start or end is reached
-    if (topInset) topInset += MARGIN;
-    if (bottomInset) bottomInset += MARGIN;
-    
+
+    // Set insets to webview
     self.webView.scrollView.contentInset = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
     self.webView.scrollView.verticalScrollIndicatorInsets = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
 }
@@ -1049,7 +1065,7 @@ BOOL isExiting = NO;
 
 - (void)showToolBar:(BOOL)show atPosition:(NSString *)toolbarPosition
 {
-    self.toolbar.hidden = !show;
+    self.toolbarBackground.hidden = !show;
     _browserOptions.toolbarposition = toolbarPosition; // Keep state consistent if needed
     [self.view setNeedsLayout];
     [self.view layoutIfNeeded];
@@ -1144,6 +1160,7 @@ BOOL isExiting = NO;
 
 - (void)webView:(WKWebView *)theWebView didStartProvisionalNavigation:(WKNavigation *)navigation
 {
+    NSLog(@"didStartProvisionalNavigation");
     // Loading URL, start spinner, update back/forward
     self.addressLabel.text = NSLocalizedString(@"Loading...", nil);
     self.backButton.enabled = theWebView.canGoBack;
@@ -1153,7 +1170,9 @@ BOOL isExiting = NO;
     return [self.navigationDelegate didStartProvisionalNavigation:theWebView];
 }
 
-- (void)webView:(WKWebView *)theWebView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+- (void)webView:(WKWebView *)theWebView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     NSURL *url = navigationAction.request.URL;
     NSURL *mainDocumentURL = navigationAction.request.mainDocumentURL;
@@ -1169,6 +1188,7 @@ BOOL isExiting = NO;
 
 - (void)webView:(WKWebView *)theWebView didFinishNavigation:(WKNavigation *)navigation
 {
+    NSLog(@"didFinishNavigation");
     // Update URL, stop spinner, update back/forward
     self.addressLabel.text = self.currentURL.absoluteString;
     self.backButton.enabled = theWebView.canGoBack;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -897,8 +897,8 @@ BOOL isExiting = NO;
     //
     // Case 1: Toolbar and Address label not visible
     if (!toolbarVisible && !addressLabelVisible) {
-        // Webview top to safe area top
-        [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+        // Webview top to top edge
+        [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
         // WebView bottom to bottom edge
         [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
     }
@@ -911,13 +911,13 @@ BOOL isExiting = NO;
             [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
             // Webview top to Toolbar bottom
             [self.webView.topAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor].active = YES;
-            // WebView to bottom edge
+            // WebView bottom to bottom edge
             [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
 
             // Toolbar is at bottom (default)
         } else {
-            // WebView top to safe area top
-            [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+            // WebView top to top edge
+            [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
             // WebView bottom to Toolbar top
             [self.webView.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor].active = YES;
             // Toolbar bottom to safe area bottom
@@ -927,8 +927,8 @@ BOOL isExiting = NO;
 
     // Case 3: Toolbar not visible, Address label visible
     if (!toolbarVisible && addressLabelVisible) {
-        // Webview top to safe area top
-        [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+        // Webview top to top edge
+        [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
         // Address label top to WebView bottom
         [self.addressLabel.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor].active = YES;
         // Address label bottom to safe area bottom
@@ -950,8 +950,8 @@ BOOL isExiting = NO;
 
             // Toolbar is at bottom (default)
         } else {
-            // WebView top to safe area top
-            [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+            // WebView top to top edge
+            [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
             // WebView bottom to Address label top
             [self.webView.bottomAnchor constraintEqualToAnchor:self.addressLabel.topAnchor].active = YES;
             // Address label bottom to Toolbar top

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -745,15 +745,19 @@ BOOL isExiting = NO;
     [self.view addSubview:self.toolbarBackground];
     
     self.toolbar = [UIToolbar new];
-    // Remove default background for toolbar on iOS 18 and older, since we provide our own
-    // backround
-    // Remove background
-    [self.toolbar setBackgroundImage:[UIImage new]
-                  forToolbarPosition:UIToolbarPositionAny
-                          barMetrics:UIBarMetricsDefault];
-    // barStyle has to be set to UIBarStyleBlack, otherwhise there would be a gray line left,
-    // after the background was removed
-    self.toolbar.barStyle = UIBarStyleBlack;
+    // Remove the toolbar background on iOS 18 and older
+    if (@available(iOS 26.0, *)) {
+        // Don't do anything on iOS 26 and newer, there is no background by default
+    } else {
+        // iOS 18 and older: Remove default background, since we provide our own backround
+        // Remove background
+        [self.toolbar setBackgroundImage:[UIImage new]
+                      forToolbarPosition:UIToolbarPositionAny
+                              barMetrics:UIBarMetricsDefault];
+        // barStyle has to be set to UIBarStyleBlack, otherwhise there would be a gray line left,
+        // after the background was removed
+        self.toolbar.barStyle = UIBarStyleBlack;
+    }
     // We add our own constraints, they should not be determined from the frame.
     self.toolbar.translatesAutoresizingMaskIntoConstraints = NO;
     [self.toolbarBackground addSubview:self.toolbar];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -874,28 +874,35 @@ BOOL isExiting = NO;
         [self.toolbarBackground.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
     ]];
 
-    // Constrain Toolbar inside Toolbar background view with padding
+    // Constrain Toolbar inside Toolbar background view with margin
     [NSLayoutConstraint activateConstraints:@[
-        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.leadingAnchor constant:10.0],
-        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.trailingAnchor constant:-10.0]
+        [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
+                                               constant:MARGIN],
+        [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor
+                                                  constant:MARGIN*-1],
+        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.leadingAnchor constant:MARGIN],
+        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.trailingAnchor constant:MARGIN*-1]
     ]];
 
     // Address background horizontal constraints with margin
     [NSLayoutConstraint activateConstraints:@[
         // Left to safe area for proper layout on landscape
         [self.addressBackgroundView.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor
-                                                                 constant:15.0],
+                                                                 constant:MARGIN],
         // Right to safe area for proper layout on landscape
         [self.addressBackgroundView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
-                                                                  constant:-15.0]
+                                                                  constant:MARGIN*-1]
     ]];
 
     // Constrain Address label inside Address background view with padding
     [NSLayoutConstraint activateConstraints:@[
-        [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor constant:10.0],
-        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.bottomAnchor constant:-10.0],
-        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.addressBackgroundView.leadingAnchor constant:10.0],
-        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.addressBackgroundView.trailingAnchor constant:-10.0]
+        [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor constant:MARGIN],
+        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.bottomAnchor
+                                                       constant:MARGIN*-1],
+        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.addressBackgroundView.leadingAnchor
+                                                        constant:MARGIN],
+        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.addressBackgroundView.trailingAnchor
+                                                         constant:MARGIN*.1]
     ]];
 
     // Define vertical constraints, in order from top to bottom
@@ -909,67 +916,65 @@ BOOL isExiting = NO;
     [self.spinner.centerYAnchor constraintEqualToAnchor:self.webView.centerYAnchor].active = YES;
 
     // Constraints for different cases set by options when Toolbar and/or Address label is visible or not
-    // Constraint WebView fullscreen and overlay Toolbar and Address label on it
-    // Webview top to top edge
-    [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
-    // WebView bottom to bottom edge
-    [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
-
-    // Case 1: Toolbar visible, Address label not visible
+    //
+    // Case 1: Toolbar and Address label not visible
+    if (!toolbarVisible && !addressLabelVisible) {
+        // Webview top to top edge
+        [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = YES;
+        // WebView bottom to bottom edge
+        [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = YES;
+    }
+    
+    // Case 2: Toolbar visible, Address label not visible
     if (toolbarVisible && !addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
             [NSLayoutConstraint activateConstraints:@[
                 // Toolbar background top to top edge
                 [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor],
-                // Toolbar background bottom to toolbar bottom with margin
-                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
-                                                                    constant:MARGIN],
-                // Toolbar top to background safe area top
-                // For landscape add a margin to top, so it's not glued to the top
-                // On portrait this only adds a subtle margin. To implement this clean, we would have to listen
-                // to the orientation change and would have to change the constant in the constraint
-                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
-                                                       constant:MARGIN]
+                // Webview top to Toolbar background bottom
+                [self.webView.topAnchor constraintEqualToAnchor:self.toolbarBackground.bottomAnchor],
+                // WebView bottom to bottom edge
+                [self.webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
             ]];
             // Toolbar is at bottom (default)
         } else {
             [NSLayoutConstraint activateConstraints:@[
-                // Toolbar background top to toolbar top with margin, margin must be negative here
-                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.toolbar.topAnchor
-                                                                 constant:MARGIN*-1],
+                // WebView top to top edge
+                [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                // WebView bottom to Toolbar background top
+                [self.webView.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.topAnchor],
                 // Toolbar background bottom to bottom edge
                 [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
-                // Toolbar bottom to background safe area bottom
-                [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor]
             ]];
         }
     }
 
-    // Case 2: Toolbar not visible, Address label visible (default)
+    // Case 3: Toolbar not visible, Address label visible
     if (!toolbarVisible && addressLabelVisible) {
         [NSLayoutConstraint activateConstraints:@[
+            // Webview top to top edge
+            [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+            // WebView bottom to Address background top with margin
+            [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
+                                                      constant:MARGIN*-1],
             // Address background bottom to safe area bottom
             [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
         ]];
     }
 
-    // Case 3: Toolbar visible and Address label visible
+    // Case 4: Toolbar visible and Address label visible (default)
     if (toolbarVisible && addressLabelVisible) {
         // Toolbar is at top
         if (toolbarIsAtTop) {
             [NSLayoutConstraint activateConstraints:@[
                 // Toolbar background top to top edge
                 [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor],
-                // Toolbar background bottom to Toolbar bottom with margin
-                [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
-                                                                    constant:MARGIN],
-                // Toolbar top to backround safe area top
-                // For landscape add margin to top, so it's not glued to the top
-                // On portrait this only adds a subtle margin. To implement this clean, we would have to listen
-                // to the orientation change and would have to change the constant in the constraint
-                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
-                                                       constant:MARGIN],
+                // Webview top to Toolbar background bottom
+                [self.webView.topAnchor constraintEqualToAnchor:self.toolbarBackground.bottomAnchor],
+                // Webview bottom to Address background top with margin
+                [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
+                                                          constant:MARGIN*-1],
                 // Address background bottom to safe area bottom
                 [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
             ]];
@@ -977,69 +982,19 @@ BOOL isExiting = NO;
             // Toolbar is at bottom (default)
         } else {
             [NSLayoutConstraint activateConstraints:@[
-                // Address background bottom to Toolbar Background top with margin, margin must be negative here
+                // WebView top to top edge
+                [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                // WebView bottom to Address background top with margin
+                [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
+                                                          constant:MARGIN*-1],
+                // Address background bottom to Toolbar Background top with margin
                 [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.topAnchor
                                                                         constant:MARGIN*-1],
-                // Toolbar background top to Toolbar top with margin, margin must be negative here
-                [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.toolbar.topAnchor
-                                                                 constant:MARGIN*-1],
                 // Toolbar background bottom to bottom edge
                 [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
-                // Toolbar bottom to background safe area bottom
-                [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor]
             ]];
         }
     }
-}
-
-- (void)viewDidLayoutSubviews
-{
-    // Setting the WebView insets must be done after the sub views are layed out,
-    // so their size are properly set and can be used for the inset calculation
-    [self setWebViewInsets];
-}
-
-/**
-    Sets `contentInset` and `verticalScrollIndicatorInsets` of the WebView for the optional
-    overlayed Toolbar and Address Bar controlled by options,  so the content can always be scrolled in the visible area.
- */
-- (void)setWebViewInsets
-{
-    // Toolbar and Address label are optional
-    BOOL toolbarVisible = _browserOptions.toolbar;
-    BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-    BOOL addressLabelVisible = _browserOptions.location;
-    // Height and width of Toolbar and Address Background, which is needed to calculate the inset of the WebView
-    const CGFloat toolbarBackgroundHeight = self.toolbarBackground.bounds.size.height;
-    const CGFloat addressBackgroundHeight = self.addressBackgroundView.bounds.size.height;
-    // Insets for the WebView, which gets calcualted
-    CGFloat topInset = 0.0;
-    CGFloat bottomInset = 0.0;
-
-    if (toolbarVisible) {
-        // Toolbar is at top
-        if (toolbarIsAtTop) {
-            topInset = toolbarBackgroundHeight - self.view.safeAreaInsets.top;
-
-            // Toolbar is at bottom (default)
-        } else {
-            bottomInset = toolbarBackgroundHeight - self.view.safeAreaInsets.bottom;
-        }
-    }
-
-    if (addressLabelVisible) {
-        // The scroll inset should have a margin to the address bar
-        bottomInset += addressBackgroundHeight + MARGIN;
-
-        // Add the margin between address bar and toolbar if toolbar is at bottom and visible
-        if (toolbarVisible && !toolbarIsAtTop) {
-            bottomInset += MARGIN;
-        }
-    }
-
-    // Set insets to webview
-    self.webView.scrollView.contentInset = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
-    self.webView.scrollView.verticalScrollIndicatorInsets = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
 }
 
 - (void)setWebViewFrame:(CGRect)frame
@@ -1201,6 +1156,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     self.addressLabel.text = self.currentURL.absoluteString;
     self.backButton.enabled = theWebView.canGoBack;
     self.forwardButton.enabled = theWebView.canGoForward;
+    theWebView.scrollView.contentInset = UIEdgeInsetsZero;
     [self.spinner stopAnimating];
     [self.navigationDelegate didFinishNavigation:theWebView];
 }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -754,7 +754,7 @@ BOOL isExiting = NO;
 
     // Background view for address label
     self.addressBackgroundView = [[UIView alloc] init];
-    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.4];
+    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
     self.addressBackgroundView.layer.cornerRadius = 15.0;
     // Don't draw any content that would be outside the view’s rectangular bounds
     self.addressBackgroundView.clipsToBounds = YES;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -38,9 +38,6 @@
 
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
-// Common margin for sub views
-#define    MARGIN 12.0
-
 #pragma mark CDVWKInAppBrowser
 
 @implementation CDVWKInAppBrowser
@@ -878,49 +875,27 @@ BOOL isExiting = NO;
     ]];
     
     // Constrain Toolbar inside Toolbar background view with margin
-    // On iOS 26 add a margin to separate the buttons from the background view
-    CGFloat toolbarTopMargin = 0.0;
-    CGFloat toolbarBottomMargin = 0.0;
-
-    if (@available(iOS 26.0, *)) {
-        // Add always a top margin, also when the toolbar is at top, so a margin is applied
-        // when the device turns to landscape
-        toolbarTopMargin = MARGIN;
-
-        // Add a bottom margin only when the toolbar is at top
-        if (toolbarIsAtTop) {
-            toolbarBottomMargin = MARGIN;
-        }
-    }
-
     [NSLayoutConstraint activateConstraints:@[
-        [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
-                                               constant:toolbarTopMargin],
-        [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor
-                                                  constant:toolbarBottomMargin*-1],
-        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.leadingAnchor constant:MARGIN],
-        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.trailingAnchor constant:MARGIN*-1]
+        [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.layoutMarginsGuide.topAnchor],
+        [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.layoutMarginsGuide.bottomAnchor],
+        [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.layoutMarginsGuide.leadingAnchor],
+        [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.layoutMarginsGuide.trailingAnchor]
     ]];
 
     // Address background horizontal constraints with margin
     [NSLayoutConstraint activateConstraints:@[
         // Left to safe area for proper layout on landscape
-        [self.addressBackgroundView.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor
-                                                                 constant:MARGIN],
+        [self.addressBackgroundView.leadingAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.leadingAnchor],
         // Right to safe area for proper layout on landscape
-        [self.addressBackgroundView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
-                                                                  constant:MARGIN*-1]
+        [self.addressBackgroundView.trailingAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.trailingAnchor]
     ]];
 
     // Constrain Address label inside Address background view with padding
     [NSLayoutConstraint activateConstraints:@[
-        [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor constant:MARGIN],
-        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.bottomAnchor
-                                                       constant:MARGIN*-1],
-        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.addressBackgroundView.leadingAnchor
-                                                        constant:MARGIN],
-        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.addressBackgroundView.trailingAnchor
-                                                         constant:MARGIN*.1]
+        [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.layoutMarginsGuide.topAnchor],
+        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.layoutMarginsGuide.bottomAnchor],
+        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.addressBackgroundView.layoutMarginsGuide.leadingAnchor],
+        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.addressBackgroundView.layoutMarginsGuide.trailingAnchor]
     ]];
 
     // Center spinner in WebView
@@ -969,9 +944,9 @@ BOOL isExiting = NO;
         [NSLayoutConstraint activateConstraints:@[
             // Webview top to top edge
             [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
-            // WebView bottom to Address background top with margin
-            [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
-                                                      constant:MARGIN*-1],
+            // Address background top to web view bottom with spacing
+            [self.addressBackgroundView.topAnchor constraintEqualToSystemSpacingBelowAnchor:self.webView.bottomAnchor
+                                                                                 multiplier:1.0],
             // Address background bottom to safe area bottom
             [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
         ]];
@@ -986,9 +961,9 @@ BOOL isExiting = NO;
                 [self.toolbarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor],
                 // Webview top to Toolbar background bottom
                 [self.webView.topAnchor constraintEqualToAnchor:self.toolbarBackground.bottomAnchor],
-                // Webview bottom to Address background top with margin
-                [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
-                                                          constant:MARGIN*-1],
+                // Address background top to web view bottom with spacing
+                [self.addressBackgroundView.topAnchor constraintEqualToSystemSpacingBelowAnchor:self.webView.bottomAnchor
+                                                                                     multiplier:1.0],
                 // Address background bottom to safe area bottom
                 [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
             ]];
@@ -998,12 +973,11 @@ BOOL isExiting = NO;
             [NSLayoutConstraint activateConstraints:@[
                 // WebView top to top edge
                 [self.webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
-                // WebView bottom to Address background top with margin
-                [self.webView.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor
-                                                          constant:MARGIN*-1],
-                // Address background bottom to Toolbar Background top with margin
-                [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.topAnchor
-                                                                        constant:MARGIN*-1],
+                // Address background top to web view bottom with spacing
+                [self.addressBackgroundView.topAnchor constraintEqualToSystemSpacingBelowAnchor:self.webView.bottomAnchor
+                                                                                     multiplier:1.0],
+                // Toolbar background top to address background bottom with spacing
+                [self.toolbarBackground.topAnchor constraintEqualToSystemSpacingBelowAnchor:self.addressBackgroundView.bottomAnchor multiplier:1.0],
                 // Toolbar background bottom to bottom edge
                 [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
             ]];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -926,7 +926,11 @@ BOOL isExiting = NO;
                 [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
                                                                     constant:MARGIN],
                 // Toolbar top to background safe area top
-                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor]
+                // For landscape add a margin to top, so it's not glued to the top
+                // On portrait this only adds a subtle margin. To implement this clean, we would have to listen
+                // to the orientation change and would have to change the constant in the constraint
+                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
+                                                       constant:MARGIN]
             ]];
             // Toolbar is at bottom (default)
         } else {
@@ -961,7 +965,11 @@ BOOL isExiting = NO;
                 [self.toolbarBackground.bottomAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor
                                                                     constant:MARGIN],
                 // Toolbar top to backround safe area top
-                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor],
+                // For landscape add margin to top, so it's not glued to the top
+                // On portrait this only adds a subtle margin. To implement this clean, we would have to listen
+                // to the orientation change and would have to change the constant in the constraint
+                [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
+                                                       constant:MARGIN],
                 // Address background bottom to safe area bottom
                 [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor]
             ]];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -749,12 +749,23 @@ BOOL isExiting = NO;
     // We add our own constraints, they should not be determined from the frame.
     self.toolbar.translatesAutoresizingMaskIntoConstraints = NO;
 
+    // Background view for address label
+    self.addressBackgroundView = [[UIView alloc] init];
+    self.addressBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
+    self.addressBackgroundView.layer.cornerRadius = 15.0;
+    // Don't draw any content that would be outside the view’s rectangular bounds
+    self.addressBackgroundView.clipsToBounds = YES;
+    [self.view addSubview:self.addressBackgroundView];
+    // We add our own constraints, they should not be determined from the frame.
+    self.addressBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+    
     self.addressLabel = [[UILabel alloc] init];
     self.addressLabel.adjustsFontSizeToFitWidth = NO;
     self.addressLabel.alpha = 1.000;
     self.addressLabel.backgroundColor = [UIColor clearColor];
     self.addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
     self.addressLabel.clearsContextBeforeDrawing = YES;
+    // Don't draw any content that would be outside the view’s rectangular bounds
     self.addressLabel.clipsToBounds = YES;
     self.addressLabel.contentMode = UIViewContentModeScaleToFill;
     self.addressLabel.enabled = YES;
@@ -775,7 +786,7 @@ BOOL isExiting = NO;
     self.addressLabel.textAlignment = NSTextAlignmentLeft;
     self.addressLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
     self.addressLabel.userInteractionEnabled = NO;
-    [self.view addSubview:self.addressLabel];
+    [self.addressBackgroundView addSubview:self.addressLabel];
     // We add our own constraints, they should not be determined from the frame.
     self.addressLabel.translatesAutoresizingMaskIntoConstraints = NO;
 
@@ -875,12 +886,22 @@ BOOL isExiting = NO;
         [self.toolbar.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
     ]];
 
-    // Address label horizontal constraints
+    // Address background horizontal constraints with margin
     [NSLayoutConstraint activateConstraints:@[
         // Left to safe area for proper layout on landscape
-        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:5.0],
+        [self.addressBackgroundView.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor
+                                                                 constant:15.0],
         // Right to safe area for proper layout on landscape
-        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-5.0]
+        [self.addressBackgroundView.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
+                                                                  constant:-15.0]
+    ]];
+    
+    // Constrain Address label inside Address background view with padding
+    [NSLayoutConstraint activateConstraints:@[
+        [self.addressLabel.topAnchor constraintEqualToAnchor:self.addressBackgroundView.topAnchor constant:10.0],
+        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.addressBackgroundView.bottomAnchor constant:-10.0],
+        [self.addressLabel.leadingAnchor constraintEqualToAnchor:self.addressBackgroundView.leadingAnchor constant:10.0],
+        [self.addressLabel.trailingAnchor constraintEqualToAnchor:self.addressBackgroundView.trailingAnchor constant:-10.0]
     ]];
 
     // Define vertical constraints, in order from top to bottom
@@ -888,7 +909,8 @@ BOOL isExiting = NO;
     BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
     BOOL toolbarVisible = _browserOptions.toolbar;
     BOOL addressLabelVisible = _browserOptions.location;
-
+    const CGFloat addressBackgroundTopBottomMargin = 12.0;
+    
     // Center spinner in WebView
     [self.spinner.centerXAnchor constraintEqualToAnchor:self.webView.centerXAnchor].active = YES;
     [self.spinner.centerYAnchor constraintEqualToAnchor:self.webView.centerYAnchor].active = YES;
@@ -929,10 +951,12 @@ BOOL isExiting = NO;
     if (!toolbarVisible && addressLabelVisible) {
         // Webview top to safe area top
         [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-        // Address label top to WebView bottom
-        [self.addressLabel.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor].active = YES;
-        // Address label bottom to safe area bottom
-        [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+        // Address background top to WebView bottom with margin
+        [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
+                                                             constant:addressBackgroundTopBottomMargin].active = YES;
+        // Address background bottom to safe area bottom with margin, margin must be negativ here
+        [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor
+                                                                constant:addressBackgroundTopBottomMargin *-1].active = YES;
     }
 
     // Case 4: Toolbar visible and Address label visible
@@ -943,19 +967,23 @@ BOOL isExiting = NO;
             [self.toolbar.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
             // Webview top to Toolbar bottom
             [self.webView.topAnchor constraintEqualToAnchor:self.toolbar.bottomAnchor].active = YES;
-            // Address label top to WebView bottom
-            [self.addressLabel.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor].active = YES;
-            // Address label bottom to safe area bottom
-            [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+            // Address background top to WebView bottom with margin
+            [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
+                                                                 constant:addressBackgroundTopBottomMargin].active = YES;
+            // Address background bottom to safe area bottom with margin, margin must be negativ here
+            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor
+                                                                    constant:addressBackgroundTopBottomMargin *-1].active = YES;
 
             // Toolbar is at bottom (default)
         } else {
             // WebView top to safe area top
             [self.webView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-            // WebView bottom to Address label top
-            [self.webView.bottomAnchor constraintEqualToAnchor:self.addressLabel.topAnchor].active = YES;
-            // Address label bottom to Toolbar top
-            [self.addressLabel.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor].active = YES;
+            // Address background top to WebView bottom with margin
+            [self.addressBackgroundView.topAnchor constraintEqualToAnchor:self.webView.bottomAnchor
+                                                                 constant:addressBackgroundTopBottomMargin].active = YES;
+            // Address background bottom to Toolbar top with margin, margin must be negativ here
+            [self.addressBackgroundView.bottomAnchor constraintEqualToAnchor:self.toolbar.topAnchor
+                                                                    constant:addressBackgroundTopBottomMargin *-1].active = YES;
             // Toolbar bottom to safe area bottom
             [self.toolbar.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
         }
@@ -986,7 +1014,7 @@ BOOL isExiting = NO;
 
 - (void)showLocationBar:(BOOL)show
 {
-    self.addressLabel.hidden = !show;
+    self.addressBackgroundView.hidden = !show;
     [self.view setNeedsLayout];
     [self.view layoutIfNeeded];
 }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -856,7 +856,10 @@ BOOL isExiting = NO;
     self.webView.allowsBackForwardNavigationGestures = NO;
 
     // Setup Auto Layout constraints
-    //
+    BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
+    BOOL toolbarVisible = _browserOptions.toolbar;
+    BOOL addressLabelVisible = _browserOptions.location;
+
     // Setup horizontal constraints
     // WebView horizontal constraints
     [NSLayoutConstraint activateConstraints:@[
@@ -873,13 +876,28 @@ BOOL isExiting = NO;
         // Right
         [self.toolbarBackground.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
     ]];
-
+    
     // Constrain Toolbar inside Toolbar background view with margin
+    // On iOS 26 add a margin to separate the buttons from the background view
+    CGFloat toolbarTopMargin = 0.0;
+    CGFloat toolbarBottomMargin = 0.0;
+
+    if (@available(iOS 26.0, *)) {
+        // Add always a top margin, also when the toolbar is at top, so a margin is applied
+        // when the device turns to landscape
+        toolbarTopMargin = MARGIN;
+
+        // Add a bottom margin only when the toolbar is at top
+        if (toolbarIsAtTop) {
+            toolbarBottomMargin = MARGIN;
+        }
+    }
+
     [NSLayoutConstraint activateConstraints:@[
         [self.toolbar.topAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.topAnchor
-                                               constant:MARGIN],
+                                               constant:toolbarTopMargin],
         [self.toolbar.bottomAnchor constraintEqualToAnchor:self.toolbarBackground.safeAreaLayoutGuide.bottomAnchor
-                                                  constant:MARGIN*-1],
+                                                  constant:toolbarBottomMargin*-1],
         [self.toolbar.leadingAnchor constraintEqualToAnchor:self.toolbarBackground.leadingAnchor constant:MARGIN],
         [self.toolbar.trailingAnchor constraintEqualToAnchor:self.toolbarBackground.trailingAnchor constant:MARGIN*-1]
     ]];
@@ -905,16 +923,12 @@ BOOL isExiting = NO;
                                                          constant:MARGIN*.1]
     ]];
 
-    // Define vertical constraints, in order from top to bottom
-    // The Address label and Toolbar are optional
-    BOOL toolbarIsAtTop = [_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-    BOOL toolbarVisible = _browserOptions.toolbar;
-    BOOL addressLabelVisible = _browserOptions.location;
-    
     // Center spinner in WebView
     [self.spinner.centerXAnchor constraintEqualToAnchor:self.webView.centerXAnchor].active = YES;
     [self.spinner.centerYAnchor constraintEqualToAnchor:self.webView.centerYAnchor].active = YES;
 
+    // Define vertical constraints, in order from top to bottom
+    // The Address label and Toolbar are optional
     // Constraints for different cases set by options when Toolbar and/or Address label is visible or not
     //
     // Case 1: Toolbar and Address label not visible


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
- Edits on 6th March 2026: I reverted to a web view with none overlaying elements.
  - I had scrolling issues, when using an iFrame in the in-app browser and the toolbar and address bar overlays the webview. It's more safe to return to the old behaviour, when nothing overlays the webview.
- Since iOS 26 the toolbar's background is not configurable anymore. To achieve this, a custom toolbar background is added, which is also used on iOS 18 and older to keep the code simple.

### Description
- The toolbar gets a white semi-transparent background by default, which can be overridden.
  - On iOS 18 and older it was dark semi-transparent before, which was changed.
- Depends on https://github.com/apache/cordova-plugin-inappbrowser/pull/1128 and https://github.com/apache/cordova-plugin-inappbrowser/pull/1129
- Overseeds https://github.com/apache/cordova-plugin-inappbrowser/pull/1097
- Fixes https://github.com/apache/cordova-plugin-inappbrowser/issues/1098
- Fixes https://github.com/apache/cordova-plugin-inappbrowser/issues/1087

#### iOS 26 Toolbar and Address bar at bottom

Default, when no options are set

| master | PR |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/ce6aec70-9273-462e-9a25-953bd5845b0d" /> | <img width="350" src="https://github.com/user-attachments/assets/2b0064a3-3bc7-44e6-888e-a44bf827c3cc" /> |

The green color is from the underyling view which opened the in-app browser.

#### iOS 18 and older Toolbar and Address bar at bottom

Default, when no options are set

| master | PR |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/45e43d34-12e4-4d54-9079-89ca70450492" /> | <img width="350" src="https://github.com/user-attachments/assets/e29b72c6-6fe9-44ac-8a82-0d12427bb1b1" /> |

The green color is from the underyling view which opened the in-app browser.

#### iOS 26 Toolbar at top Address bar at bottom

| master | PR |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/5435dd4e-012f-4478-bfe5-67826fba25bd" /> | <img width="350" src="https://github.com/user-attachments/assets/2509345d-0153-4d1c-bf27-515b081daf60" /> |

The green color is from the underyling view which opened the in-app browser.

#### iOS 18 and older Toolbar at top Address bar at bottom

| master | PR |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/4686ab73-1194-4259-9c47-e14f02f7ba7d" /> | <img width="350" src="https://github.com/user-attachments/assets/3d23326b-0f14-493a-a7fe-4c759f15a59b" /> |

The green color is from the underyling view which opened the in-app browser.

#### Landscape Toolbar Top fix

On landscape, when the toolbar is at top it was too close to the top edge, which is fixed:

| master | PR |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/102e67c5-c8ca-4e98-aa4d-a1553d5301b8" /> | <img width="350" src="https://github.com/user-attachments/assets/4d74ef53-fa37-46c6-aa96-8201e0725125" /> |

#### Set Custom Toolbar Background Color

| Translucent | None translucent |
| :---: | :---: |
| <img width="350" src="https://github.com/user-attachments/assets/4ee7335c-3bbe-4fb4-81e6-a3e02e7001aa" /> | <img width="350" src="https://github.com/user-attachments/assets/97fd56b1-73e7-4297-8cf6-d8da89e062c9" /> |
| Set `toolbarcolor=#FF0000` with`toolbartranslucent=yes` which is the default | Set `toolbarcolor=#FF0000` and `toolbartranslucent=no` |

### Testing

All options were tested with the new layout:
- Toolbar and address bar hidden
- Toolbar visible at bottom or top, address bar hidden
- Toolbar visible at bottom or top, address bar visible
- Test on iOS 18 and iOS 26

### Other changes
- Fixes the toolbar is glued at the top on landscape
- Address bar: Text is black by default and the background transparent white
  - Removed some unnecessary assigned properties
- Toolbar: Removed some unnecessary assigned properties
- doc(readme): change some wording for iOS option `toolbartranslucent`
- Use always `[NSLayoutConstraint activateConstraints:]` to activate constraints

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
