### PR TITLE
chore(gitattributes): normalize line endings and binary detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation, Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update `.gitattributes` to properly handle line ending normalization.

When cloning the repo, git showed warnings for PNG files such as:

> CRLF will be replaced by LF the next time Git touches it

Switching to `text=auto` allowed git to safely apply LF normalization to text files while preserving binary files through automatic detection.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
