### PR TITLE
fix(ios): set callbackId only on target=_blank, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ instance, or the system browser.
 
     var ref = cordova.InAppBrowser.open(url, target, options);
 
-- __ref__: Reference to the `InAppBrowser` window when the target is set to `'_blank'`. _(InAppBrowser)_
+- __ref__: Reference to the `InAppBrowser` window when the target is set to `'_blank'`. _(InAppBrowser)_ On Android, non-whitelisted URLs also fall back to the `InAppBrowser` when the target is set to `'_self'`.
 
 - __url__: The URL to load _(String)_. Call `encodeURI()` on this if the URL contains Unicode characters.
 
 - __target__: The target in which to load the URL, an optional parameter that defaults to `_self`. _(String)_
 
-    - `_self`: Opens in the Cordova WebView if the URL is in the white list, otherwise it opens in the `InAppBrowser`.
+    - `_self`: Opens in the Cordova WebView. On Android, non-whitelisted URLs fall back to the `InAppBrowser`. On iOS, the current implementation does not perform this fallback and navigation remains in the Cordova WebView (subject to `<allow-navigation>`).
     - `_blank`: Opens in the `InAppBrowser`.
     - `_system`: Opens in the system's web browser.
 
@@ -180,6 +180,8 @@ Since the introduction of iPadOS 13, iPads try to adapt their content mode / use
 ```
 
 The example above forces the user agent to contain `iPad`. The other option is to use the value `desktop` to turn the user agent to `Macintosh`.
+
+The current iOS implementation of `target='_self'` does not fall back to `InAppBrowser` for non-whitelisted URLs. If you need guaranteed `InAppBrowser` behavior on iOS, use `target='_blank'`.
 
 ### Browser Quirks
 
@@ -744,11 +746,13 @@ iab.open('https://whitelisted-url.com', 'random_string', 'location=no'); // load
 
 ### Urls that are not white-listed
 
+Platform note: `_self` differs by platform for non-whitelisted URLs. On Android it falls back to `InAppBrowser`. On iOS it stays in the Cordova WebView and is controlled by `<allow-navigation>`.
+
 ```
 var iab = cordova.InAppBrowser;
 
 iab.open('https://url-that-fails-whitelist.com');                  // loads in the InAppBrowser
-iab.open('https://url-that-fails-whitelist.com', '_self');         // loads in the InAppBrowser
+iab.open('https://url-that-fails-whitelist.com', '_self');         // Android: loads in the InAppBrowser, iOS: handled by Cordova WebView rules
 iab.open('https://url-that-fails-whitelist.com', '_system');       // loads in the system browser
 iab.open('https://url-that-fails-whitelist.com', '_blank');        // loads in the InAppBrowser
 iab.open('https://url-that-fails-whitelist.com', 'random_string'); // loads in the InAppBrowser

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -76,26 +76,32 @@
 - (void)open:(CDVInvokedUrlCommand *)command
 {
     CDVPluginResult *pluginResult;
-
     NSString *url = [command argumentAtIndex:0];
     NSString *target = [command argumentAtIndex:1 withDefault:kInAppBrowserTargetSelf];
     NSString *options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
 
-    self.callbackId = command.callbackId;
-
     if (url != nil) {
-        NSURL *baseUrl = [self.webViewEngine URL];
-        NSURL *absoluteUrl = [[NSURL URLWithString:url relativeToURL:baseUrl] absoluteURL];
+        NSURL *absoluteUrl = [[NSURL URLWithString:url
+                                     relativeToURL:[self.webViewEngine URL]] absoluteURL];
 
         if ([self isSystemUrl:absoluteUrl]) {
             target = kInAppBrowserTargetSystem;
         }
 
+        // target=_self - Open in Cordova WebView
         if ([target isEqualToString:kInAppBrowserTargetSelf]) {
             [self openInCordovaWebView:absoluteUrl withOptions:options];
+            
+            // target=_system - Open external
         } else if ([target isEqualToString:kInAppBrowserTargetSystem]) {
             [self openInSystem:absoluteUrl];
-        } else { // _blank or anything else
+            
+            // target=_blank or anything else, open in in-app browser
+        } else {
+            // Only set the command callback id here
+            // Don't set or overwrite it when target _system or _self is called, cause this will
+            // not invoke an in-app browser instance
+            self.callbackId = command.callbackId;
             [self openInInAppBrowser:absoluteUrl withOptions:options];
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I want to open a link in the external browser, which is clicked in the in-app browser, by listening to the event `beforeload` and open the link by `cordova.InAppBrowser.open(externalUrl, '_system')`. After doing that, the `beforeload` event is not triggered anymore because the in-app browser reference has changed by `open(externalUrl, '_system')`. Since `_system` is used and the in-app browser just forwards the call, it's is not necessary to change the reference. Also the documentation states that the reference to the `InAppBrowser` window is set, when the target is set to `'_blank'` only.

On Android, non-whitelisted URLs also fall back to the `InAppBrowser` when the target is set to `'_self'`, which is not the case on iOS. This case was updated in the README.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested successfully in an App with the event `beforeload` and opening a specific link external:

```js
const inAppBrowserRef = cordova.InAppBrowser.open(url, "_blank", "beforeload=yes");

inAppBrowserRef.addEventListener("beforeload", (inAppBrowserEvent, callback) => {
      // Open clicked link external
      if (inAppBrowserEvent.url == "https://myExternalUrl.com") {
        cordova.InAppBrowser.open(inAppBrowserEvent.url, "_system");
      } else {
        // Load URL in in-app browser
        callback(inAppBrowserEvent.url);
      }
});
```

On Android only the first page load in the in-app browser will fire `beforeload`. After this the event will not be fired again, e.g. when a link is clicked, which seems to be a bug on Android and has nothing to do with this PR.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
