### PR TITLE
fix(ios): don't call `beforeload` on POST and `beforeload=yes`

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -453,8 +453,9 @@
 - (void)webView:(WKWebView *)theWebView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     NSURL *url = navigationAction.request.URL;
-    NSURL *mainDocumentURL = navigationAction.request.mainDocumentURL;
-    BOOL isTopLevelNavigation = [url isEqual:mainDocumentURL];
+    BOOL isTopLevelNavigation =
+        (navigationAction.targetFrame == nil) ||
+        navigationAction.targetFrame.isMainFrame;
     BOOL shouldStart = YES;
     BOOL useBeforeLoad = NO;
     NSString *httpMethod = navigationAction.request.HTTPMethod;
@@ -463,12 +464,11 @@
     if ([_beforeload isEqualToString:@"post"]) {
         // TODO: Handle POST requests by preserving POST data then remove this condition.
         errorMessage = @"beforeload doesn't yet support POST requests";
-    } else if (isTopLevelNavigation && (
-        [_beforeload isEqualToString:@"yes"]
-        || ([_beforeload isEqualToString:@"get"] && [httpMethod isEqualToString:@"GET"])
-        // TODO: Comment in when POST requests are handled.
-        // || ([_beforeload isEqualToString:@"post"] && [httpMethod isEqualToString:@"POST"])
-    )) {
+
+        // beforeload only on GET and when the appropriate option is set
+    } else if (isTopLevelNavigation
+               && [httpMethod isEqualToString:@"GET"]
+               && ([_beforeload isEqualToString:@"yes"] || [_beforeload isEqualToString:@"get"])) {
         useBeforeLoad = YES;
     }
 
@@ -1145,9 +1145,9 @@ decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
 decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     NSURL *url = navigationAction.request.URL;
-    NSURL *mainDocumentURL = navigationAction.request.mainDocumentURL;
-
-    BOOL isTopLevelNavigation = [url isEqual:mainDocumentURL];
+    BOOL isTopLevelNavigation =
+        (navigationAction.targetFrame == nil) ||
+        navigationAction.targetFrame.isMainFrame;
 
     if (isTopLevelNavigation) {
         self.currentURL = url;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- If the option `beforeload=yes` was set and a POST-Request was made, `beforeload` was fired which was wrong, because POST-Request are not supported currently for beforeload
- Improve dectection for `isTopLevelNavigation`: Using `targetFrame` makes top-level detection based on actual frame intent, not URL coincidence, so the interception logic is more correct and robust.
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
