### PR TITLE
fix(ios): suppress expected cancellation errors when `beforeload` is set

### DIFF
--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -51,6 +51,7 @@ typedef NSDictionary CDVSettingsDictionary;
 - (void)show:(CDVInvokedUrlCommand *)command;
 - (void)hide:(CDVInvokedUrlCommand *)command;
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand *)command;
+- (BOOL)isBeforeloadEnabled;
 
 @end
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -341,6 +341,11 @@
     [self.inAppBrowserViewController navigateTo:url];
 }
 
+- (BOOL)isBeforeloadEnabled
+{
+    return ![_beforeload isEqualToString:@""];
+}
+
 // This is a helper method for the inject{Script|Style}{Code|File} API calls, which
 // provides a consistent method for injecting JavaScript code into the document.
 //
@@ -1170,11 +1175,28 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 
 - (void)webView:(WKWebView *)theWebView failedNavigation:(NSString *) delegateName withError:(nonnull NSError *)error
 {
-    // Log fail message, stop spinner, update back/forward
-    NSLog(@"webView:%@ - %ld: %@", delegateName, (long)error.code, [error localizedDescription]);
     self.backButton.enabled = theWebView.canGoBack;
     self.forwardButton.enabled = theWebView.canGoForward;
     [self.spinner stopAnimating];
+
+    BOOL isBeforeloadEnabled = self.navigationDelegate != nil && [self.navigationDelegate isBeforeloadEnabled];
+    
+    // When using beforeload, navigations are intentionally cancelled and restarted.
+    // This results in expected cancellation errors with code NSURLErrorCancelled or
+    // WebKitErrorDomain code 102. Suppress these expected cancellation errors so
+    // they do not trigger false loaderror events.
+    BOOL isExpectedCancellation =
+        isBeforeloadEnabled && (
+            (error.code == NSURLErrorCancelled) ||
+            ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102)
+        );
+
+    if (isExpectedCancellation) {
+        return;
+    }
+
+    // Populate error
+    NSLog(@"webView:%@ - %ld: %@", delegateName, (long)error.code, [error localizedDescription]);
     self.addressLabel.text = NSLocalizedString(@"Load Error", nil);
     [self.navigationDelegate webView:theWebView didFailNavigation:error];
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- If `beforeload` is set, there will an error logged for every page load: `webView:didFailProvisionalNavigation - 102: Frame load interrupted`. Now the error will be suppressed if `beforeload` is set.
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
