### PR TITLE
fix(android): `beforeload` event fires only once

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -926,34 +926,48 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
                     @Override
                     public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+                        // New-window navigations (for example window.open or target=_blank)
+                        // are delivered here by WebView. We do not show a second visible
+                        // browser window; instead, we route that navigation back into the
+                        // current InAppBrowser WebView so existing lifecycle and beforeload
+                        // handling remain consistent.
                         final WebView inAppWebView = view;
                         final WebViewClient webViewClient = new WebViewClient() {
                             @Override
                             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-                                String targetUrl = request.getUrl().toString();
-                                if ("about:blank".equals(targetUrl)) {
-                                    return false;
-                                }
-                                if (currentClient != null && currentClient.shouldOverrideUrlLoading(targetUrl, request.getMethod())) {
-                                    return true;
-                                }
-                                inAppWebView.loadUrl(targetUrl);
-                                return true;
+                                return handleNewWindowUrl(request.getUrl().toString(), request.getMethod());
                             }
 
                             @Override
                             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                                if ("about:blank".equals(url)) {
+                                return handleNewWindowUrl(url, null);
+                            }
+
+                            private boolean handleNewWindowUrl(String targetUrl, String method) {
+                                // WebView commonly initializes popup flows with about:blank.
+                                // Forwarding this placeholder URL into the main WebView can
+                                // replace the current page and break subsequent navigation,
+                                // so it must be ignored.
+                                if ("about:blank".equals(targetUrl)) {
                                     return false;
                                 }
-                                if (currentClient != null && currentClient.shouldOverrideUrlLoading(url, null)) {
+
+                                // Reuse the main client so beforeload and scheme routing are
+                                // applied exactly like regular navigations.
+                                if (currentClient != null && currentClient.shouldOverrideUrlLoading(targetUrl, method)) {
                                     return true;
                                 }
-                                inAppWebView.loadUrl(url);
+
+                                // If the main client did not consume the request, continue by
+                                // loading the URL in the currently visible InAppBrowser view.
+                                inAppWebView.loadUrl(targetUrl);
                                 return true;
                             }
                         };
 
+                        // Attach a temporary transport WebView required by the Android
+                        // onCreateWindow contract. Its client forwards navigation decisions
+                        // to the active InAppBrowser WebView/client above.
                         final WebView newWebView = new WebView(view.getContext());
                         newWebView.setWebViewClient(webViewClient);
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -933,11 +933,19 @@ public class InAppBrowser extends CordovaPlugin {
                         // handling remain consistent.
                         final WebView inAppWebView = view;
                         final WebViewClient webViewClient = new WebViewClient() {
+                            /**
+                             * New (added in API 24)
+                             * For Android 7 and above.
+                             */
                             @Override
                             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
                                 return handleNewWindowUrl(request.getUrl().toString(), request.getMethod());
                             }
 
+                            /**
+                             * Legacy (deprecated in API 24)
+                             * For Android 6 and below.
+                             */
                             @Override
                             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                                 return handleNewWindowUrl(url, null);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -35,6 +35,7 @@ import android.net.http.SslError;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Message;
 import android.text.InputType;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -923,6 +924,46 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView.setId(Integer.valueOf(6));
                 // File Chooser Implemented ChromeClient
                 inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
+                    @Override
+                    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+                        final WebView inAppWebView = view;
+                        final WebViewClient webViewClient = new WebViewClient() {
+                            @Override
+                            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                                String targetUrl = request.getUrl().toString();
+                                if ("about:blank".equals(targetUrl)) {
+                                    return false;
+                                }
+                                if (currentClient != null && currentClient.shouldOverrideUrlLoading(targetUrl, request.getMethod())) {
+                                    return true;
+                                }
+                                inAppWebView.loadUrl(targetUrl);
+                                return true;
+                            }
+
+                            @Override
+                            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                                if ("about:blank".equals(url)) {
+                                    return false;
+                                }
+                                if (currentClient != null && currentClient.shouldOverrideUrlLoading(url, null)) {
+                                    return true;
+                                }
+                                inAppWebView.loadUrl(url);
+                                return true;
+                            }
+                        };
+
+                        final WebView newWebView = new WebView(view.getContext());
+                        newWebView.setWebViewClient(webViewClient);
+
+                        final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
+                        transport.setWebView(newWebView);
+                        resultMsg.sendToTarget();
+
+                        return true;
+                    }
+
                     public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
                     {
                         LOG.d(LOG_TAG, "File Chooser 5.0+");
@@ -1373,6 +1414,11 @@ public class InAppBrowser extends CordovaPlugin {
         public void onPageFinished(WebView view, String url) {
             super.onPageFinished(view, url);
 
+            // Re-arm beforeload after allowing the previously approved navigation.
+            if (beforeload != null && !beforeload.isEmpty()) {
+                this.waitForBeforeload = true;
+            }
+
             // Set the namespace for postMessage()
             injectDeferredObject("window.webkit={messageHandlers:{cordova_iab:cordova_iab}}", null);
 
@@ -1396,6 +1442,11 @@ public class InAppBrowser extends CordovaPlugin {
 
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
             super.onReceivedError(view, errorCode, description, failingUrl);
+
+            // Ensure future navigations can still trigger beforeload after an error.
+            if (beforeload != null && !beforeload.isEmpty()) {
+                this.waitForBeforeload = true;
+            }
 
             try {
                 JSONObject obj = new JSONObject();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- When beforeload=yes was set, the beforeload event would only fire on the initial page load, then stop firing for subsequent navigations.
- Route onCreateWindow navigation through the active InAppBrowser client so beforeload and URL overrides are consistently applied
- Ignore transient about:blank bootstrap URLs from new-window flow to avoid breaking the visible page
- Re-arm waitForBeforeload after page finish and load error so interception keeps working after the first allowed navigation
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
