### PR TITLE
fix(android): change callback context only on non-whitelisted urls or target `_blank`

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -169,11 +169,6 @@ public class InAppBrowser extends CordovaPlugin {
                 t = SELF;
             }
             final String target = t;
-            // Keep the existing callback channel when opening _system from inside
-            // an active InAppBrowser instance (e.g. from beforeload handling).
-            if (!SYSTEM.equals(target)) {
-                this.callbackContext = callbackContext;
-            }
             final HashMap<String, String> features = parseFeature(args.optString(2));
 
             LOG.d(LOG_TAG, "target = " + target);
@@ -240,6 +235,7 @@ public class InAppBrowser extends CordovaPlugin {
                         // load in InAppBrowser
                         else {
                             LOG.d(LOG_TAG, "loading in InAppBrowser");
+                            InAppBrowser.this.callbackContext = callbackContext;
                             result = showWebPage(url, features);
                         }
                     }
@@ -251,6 +247,7 @@ public class InAppBrowser extends CordovaPlugin {
                     // BLANK - or anything else
                     else {
                         LOG.d(LOG_TAG, "in blank");
+                        InAppBrowser.this.callbackContext = callbackContext;
                         result = showWebPage(url, features);
                     }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -163,13 +163,17 @@ public class InAppBrowser extends CordovaPlugin {
      */
     public boolean execute(String action, CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         if (action.equals("open")) {
-            this.callbackContext = callbackContext;
             final String url = args.getString(0);
             String t = args.optString(1);
             if (t == null || t.equals("") || t.equals(NULL)) {
                 t = SELF;
             }
             final String target = t;
+            // Keep the existing callback channel when opening _system from inside
+            // an active InAppBrowser instance (e.g. from beforeload handling).
+            if (!SYSTEM.equals(target)) {
+                this.callbackContext = callbackContext;
+            }
             final HashMap<String, String> features = parseFeature(args.optString(2));
 
             LOG.d(LOG_TAG, "target = " + target);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Opening a link externally via `_system` in a `beforeload` callback, would break the `beforeload` callback for the remaining InAppBrowser session.
- The callback context was always changed, when `open` was called, no matter what should be loaded. Now it will only be set for non-whitelisted urls and target `_blank`, like the documentation already states.
- It is not applied anymore for:
  - _system
  - _self + whitelisted URL
  - _self + tel:
- Fixes https://github.com/apache/cordova-plugin-inappbrowser/issues/752
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
