### PR TITLE
fix(android): place footer below WebView instead of overlaying content

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1047,12 +1047,14 @@ public class InAppBrowser extends CordovaPlugin {
 
                 // Add our webview to our main view/layout
                 RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());
+                webViewLayout.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, 0, 1.0f));
                 webViewLayout.addView(inAppWebView);
                 main.addView(webViewLayout);
 
                 // Don't add the footer unless it's been enabled
                 if (showFooter) {
-                    webViewLayout.addView(footer);
+                    footer.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(TOOLBAR_HEIGHT)));
+                    main.addView(footer);
                 }
 
                 WindowManager.LayoutParams lp = new WindowManager.LayoutParams();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- On Android, enabling footer=yes adds the footer as a child of the WebView container, so it is rendered on top of the page content. This causes the bottom of the page to be obscured unless the loaded site adds manual bottom padding.
- This change moves the footer into the main vertical layout flow below the WebView and gives the WebView container a weighted height. That way, the footer keeps its fixed height while the WebView uses the remaining space, and page content is no longer covered by the native footer.
- Set the WebView container to LinearLayout.LayoutParams(MATCH_PARENT, 0, 1.0f).
- Stop adding the footer as an overlay inside webViewLayout.
- Add the footer directly to the main vertical layout with its own fixed toolbar-height layout params.
- Fixes: https://github.com/apache/cordova-plugin-inappbrowser/issues/294
- Generated-By: GPT-5.4

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
