### PR TITLE
fix(types): support beforeload listener signature in TypeScript defs

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 // Copyright (c) Microsoft Open Technologies Inc
 // Licensed under the MIT license.
 // TypeScript Version: 2.3
-type channel = "loadstart" | "loadstop" | "loaderror" | "exit" | "message" | "customscheme";
+type channel = "loadstart" | "loadstop" | "loaderror" | "exit" | "message" | "customscheme" | "beforeload";
 
 /**
  * The object returned from a call to cordova.InAppBrowser.open.
@@ -37,8 +37,19 @@ interface InAppBrowser {
      *                  exit: event fires when the InAppBrowser window is closed.
      * @param callback  the function that executes when the event fires. The function is
      *                  passed an InAppBrowserEvent object as a parameter.
+     *
+     * NOTE: beforeload is intentionally excluded here and modeled with a dedicated overload because the
+     * callback parameter is of a different type.
      */
-    addEventListener(type: channel, callback: InAppBrowserEventListenerOrEventListenerObject): void;
+    addEventListener(type: Exclude<channel, "beforeload">, callback: InAppBrowserEventListenerOrEventListenerObject): void;
+    /**
+     * Adds a listener for the beforeload event from the InAppBrowser.
+     * @param type      beforeload: event fires when the InAppBrowser decides whether to load a URL or not.
+     * @param callback  the function that executes when the event fires. The function is
+     *                  passed an InAppBrowserEvent object and a callback function that can be
+     *                  invoked to continue loading with a URL.
+     */
+    addEventListener(type: "beforeload", callback: InAppBrowserBeforeloadEventListener): void;
     /**
      * Adds a listener for an event from the InAppBrowser.
      * @param type      any custom event that might occur.
@@ -56,8 +67,17 @@ interface InAppBrowser {
      *                  exit: event fires when the InAppBrowser window is closed.
      * @param callback  the function that executes when the event fires. The function is
      *                  passed an InAppBrowserEvent object as a parameter.
+     *
+     * NOTE: beforeload is intentionally excluded here and modeled with a dedicated overload because the
+     * callback parameter is of a different type.
      */
-    removeEventListener(type: channel, callback: InAppBrowserEventListenerOrEventListenerObject): void;
+    removeEventListener(type: Exclude<channel, "beforeload">, callback: InAppBrowserEventListenerOrEventListenerObject): void;
+    /**
+     * Removes a listener for the beforeload event from the InAppBrowser.
+     * @param type      beforeload: event fires when the InAppBrowser decides whether to load a URL or not.
+     * @param callback  the function that executes when the event fires.
+     */
+    removeEventListener(type: "beforeload", callback: InAppBrowserBeforeloadEventListener): void;
     /** Closes the InAppBrowser window. */
     close(): void;
     /** Hides the InAppBrowser window. Calling this has no effect if the InAppBrowser was already hidden. */
@@ -89,12 +109,14 @@ type InAppBrowserEventListenerOrEventListenerObject = InAppBrowserEventListener 
 
 type InAppBrowserEventListener = (evt: InAppBrowserEvent) => void;
 
+type InAppBrowserBeforeloadEventListener = (evt: InAppBrowserEvent, callback: (url: string) => void) => void;
+
 interface InAppBrowserEventListenerObject {
     handleEvent(evt: InAppBrowserEvent): void;
 }
 
 interface InAppBrowserEvent extends Event {
-    /** the eventname, either `loadstart`, `loadstop`, `loaderror`, `exit`, `message`, or `customscheme`. */
+    /** the eventname, either `loadstart`, `loadstop`, `loaderror`, `exit`, `message`, `customscheme`, or `beforeload`. */
     type: string;
     /** the URL that was loaded. */
     url: string;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- add explicit beforeload event typing for addEventListener/removeEventListener
- keep beforeload separated from generic event overload to avoid overload mismatch errors
- clarify inline docs about why beforeload uses its own overload
- Fixes https://github.com/apache/cordova-plugin-inappbrowser/issues/1084
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
