### PR TITLE
fix: defer navigation until async cookie or data clearing completes

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -743,6 +743,36 @@ public class InAppBrowser extends CordovaPlugin {
                 return value;
             }
 
+            /**
+             * Clears cookies according to the active options and invokes completion when finished.
+             *
+             * Cookie clearing APIs are asynchronous (API 22+), so loadUrl must run in the callback
+             * to avoid a race where navigation starts before cookie deletion is complete.
+             */
+            private void clearCookies(final Runnable completion) {
+                final CookieManager cookieManager = CookieManager.getInstance();
+
+                if (clearAllCache) {
+                    cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
+                        @Override
+                        public void onReceiveValue(Boolean value) {
+                            cookieManager.flush();
+                            completion.run();
+                        }
+                    });
+                } else if (clearSessionCache) {
+                    cookieManager.removeSessionCookies(new ValueCallback<Boolean>() {
+                        @Override
+                        public void onReceiveValue(Boolean value) {
+                            cookieManager.flush();
+                            completion.run();
+                        }
+                    });
+                } else {
+                    completion.run();
+                }
+            }
+
             private View createCloseButton(int id) {
                 View _close;
                 Resources activityRes = cordova.getActivity().getResources();
@@ -1026,16 +1056,16 @@ public class InAppBrowser extends CordovaPlugin {
                 }
                 settings.setDomStorageEnabled(true);
 
-                if (clearAllCache) {
-                    CookieManager.getInstance().removeAllCookie();
-                } else if (clearSessionCache) {
-                    CookieManager.getInstance().removeSessionCookie();
-                }
-
                 // Enable Thirdparty Cookies
                 CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView,true);
 
-                inAppWebView.loadUrl(url);
+                // Delay navigation until cookie clearing is complete (or skipped).
+                clearCookies(new Runnable() {
+                    @Override
+                    public void run() {
+                        inAppWebView.loadUrl(url);
+                    }
+                });
                 inAppWebView.setId(Integer.valueOf(6));
                 inAppWebView.getSettings().setLoadWithOverviewMode(true);
                 inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -120,8 +120,6 @@
 {
     CDVInAppBrowserOptions *browserOptions = [CDVInAppBrowserOptions parseOptions:options];
 
-    [self clearWebsiteDataByOptions:browserOptions];
-
     if (self.inAppBrowserViewController == nil) {
         self.inAppBrowserViewController = [[CDVWKInAppBrowserViewController alloc] initWithBrowserOptions: browserOptions andSettings:self.commandDelegate.settings];
         self.inAppBrowserViewController.navigationDelegate = self;
@@ -176,10 +174,19 @@
     }
     _waitForBeforeload = ![_beforeload isEqualToString:@""];
 
-    [self.inAppBrowserViewController navigateTo:url];
-    if (!browserOptions.hidden) {
-        [self show:nil withNoAnimate:browserOptions.hidden];
-    }
+    __weak CDVWKInAppBrowser *weakSelf = self;
+    // Delay the initial navigation until requested clearing operations complete.
+    [self clearWebsiteDataByOptions:browserOptions completionHandler:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf == nil || strongSelf.inAppBrowserViewController == nil) {
+            return;
+        }
+
+        [strongSelf.inAppBrowserViewController navigateTo:url];
+        if (!browserOptions.hidden) {
+            [strongSelf show:nil withNoAnimate:browserOptions.hidden];
+        }
+    }];
 }
 
 /**
@@ -187,42 +194,100 @@
  * This will clear the data on the Cordova WebView also.
  *
  * @param browserOptions The options specifying which types of data to clear.
+ * @param completionHandler Called after all requested clearing operations are complete.
  */
-- (void)clearWebsiteDataByOptions:(CDVInAppBrowserOptions *)browserOptions
+- (void)clearWebsiteDataByOptions:(CDVInAppBrowserOptions *)browserOptions completionHandler:(void (^)(void))completionHandler
 {
     // NOTE: [WKWebsiteDataStore defaultDataStore] will get the default data store of the app,
     // which is shared between all WKWebViews, which means also the Cordova WebView
     WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
 
+    // Option precedence:
+    // 1) cleardata: clears all web data (including cookies), so cookie options are skipped.
+    // 2) clearcache: clears all cookies (session + persistent).
+    // 3) clearsessioncache: clears only session cookies.
+    // 4) no clear options: continue immediately.
     if (browserOptions.cleardata) {
-        [dataStore fetchDataRecordsOfTypes:WKWebsiteDataStore.allWebsiteDataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> * _Nonnull records) {
-            [dataStore removeDataOfTypes:WKWebsiteDataStore.allWebsiteDataTypes forDataRecords:records completionHandler:^{
-                NSLog(@"Removed all WKWebView data");
-                // Create new WKProcessPool
-                if (@available(iOS 15.0, *)) {
-                    // Since iOS 15 WKProcessPool is deprecated and has no effect
-                } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                    // Set for iOS 14 and below a new process pool
-                    self.inAppBrowserViewController.webView.configuration.processPool = [[WKProcessPool alloc] init]; // create new process pool to flush all data
-#pragma clang diagnostic pop
-            }
-            }];
-        }];
+        [self clearData:dataStore completionHandler:completionHandler];
+        return;
     }
 
-    // Deletes all cookies or session cookies
-    if (browserOptions.clearcache || browserOptions.clearsessioncache) {
-        WKHTTPCookieStore *cookieStore = dataStore.httpCookieStore;
-        [cookieStore getAllCookies:^(NSArray *cookies) {
-            for (NSHTTPCookie *cookie in cookies) {
-                if (browserOptions.clearcache || (browserOptions.clearsessioncache && cookie.sessionOnly)) {
-                    [cookieStore deleteCookie:cookie completionHandler:nil];
-                }
+    if (browserOptions.clearcache) {
+        [self clearCookie:dataStore sessionOnly:NO completionHandler:completionHandler];
+        return;
+    }
+
+    if (browserOptions.clearsessioncache) {
+        [self clearCookie:dataStore sessionOnly:YES completionHandler:completionHandler];
+        return;
+    }
+
+    if (completionHandler != nil) {
+        completionHandler();
+    }
+}
+
+/**
+ * Clears all WKWebView website data types (cookies, local storage, IndexedDB, cache, etc.).
+ */
+- (void)clearData:(WKWebsiteDataStore *)dataStore completionHandler:(void (^)(void))completionHandler
+{
+    [dataStore fetchDataRecordsOfTypes:WKWebsiteDataStore.allWebsiteDataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> * _Nonnull records) {
+        [dataStore removeDataOfTypes:WKWebsiteDataStore.allWebsiteDataTypes forDataRecords:records completionHandler:^{
+            NSLog(@"Removed all WKWebView data");
+            // Create new WKProcessPool
+            if (@available(iOS 15.0, *)) {
+                // Since iOS 15 WKProcessPool is deprecated and has no effect
+            } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                // Set for iOS 14 and below a new process pool
+                self.inAppBrowserViewController.webView.configuration.processPool = [[WKProcessPool alloc] init]; // create new process pool to flush all data
+#pragma clang diagnostic pop
+            }
+
+            if (completionHandler != nil) {
+                completionHandler();
             }
         }];
-    }
+    }];
+}
+
+/**
+ * Clears cookies from the shared cookie store.
+ * sessionOnly=NO: clear all cookies.
+ * sessionOnly=YES: clear only session cookies.
+ */
+- (void)clearCookie:(WKWebsiteDataStore *)dataStore sessionOnly:(BOOL)sessionOnly completionHandler:(void (^)(void))completionHandler
+{
+    WKHTTPCookieStore *cookieStore = dataStore.httpCookieStore;
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        NSMutableArray<NSHTTPCookie *> *cookiesToDelete = [NSMutableArray array];
+        for (NSHTTPCookie *cookie in cookies) {
+            if (!sessionOnly || cookie.sessionOnly) {
+                [cookiesToDelete addObject:cookie];
+            }
+        }
+
+        // No cookies available, return
+        if (cookiesToDelete.count == 0) {
+            if (completionHandler != nil) {
+                completionHandler();
+            }
+            return;
+        }
+
+        // [WKHTTPCookieStore deleteCookie] is async, so complete only after the final callback.
+        __block NSUInteger pendingCookieDeletes = cookiesToDelete.count;
+        for (NSHTTPCookie *cookie in cookiesToDelete) {
+            [cookieStore deleteCookie:cookie completionHandler:^{
+                pendingCookieDeletes--;
+                if (pendingCookieDeletes == 0 && completionHandler != nil) {
+                    completionHandler();
+                }
+            }];
+        }
+    }];
 }
 
 - (void)show:(CDVInvokedUrlCommand *)command


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android
- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Fixes #521: Cookies were persisting despite clearcache/clearsessioncache options because navigation started before async clearing operations finished, causing a race condition.
- Generated-By: GPT-5.3-Codex

#### Android (src/android/InAppBrowser.java)
- Extract cookie clearing into async clearCookies() method
- Use modern async APIs (removeAllCookies/removeSessionCookies with callbacks)
- Drop legacy pre-API 22 fallbacks (minimum supported is Android 5.1, API 22)
- Defer inAppWebView.loadUrl() until cookie clearing callback completes
- Add documentation explaining the async sequencing requirement

#### iOS (src/ios/CDVWKInAppBrowser.m)
- Refactor clearing logic into two focused methods:
  - clearData: removes all website data (cookies, localStorage, IndexedDB, cache)
  - clearCookie(sessionOnly): removes all or session-only cookies
- Implement option precedence in clearWebsiteDataByOptions:
  1. cleardata (covers all, including cookies)
  2. clearcache (all cookies)
  3. clearsessioncache (session cookies only)
  4. no option (skip clearing)
- Defer navigateTo/show until clearing completion callbacks fire
- Add comprehensive inline documentation for flow and async operations


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
