### PR TITLE
fix(ios): replace macro `kCloseButtonSystemItem` with static function to fix XCode warning

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -38,7 +38,14 @@
 
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
-#define    kCloseButtonSystemItem (@available(iOS 26.0, *) ? UIBarButtonSystemItemClose : UIBarButtonSystemItemDone)
+static UIBarButtonSystemItem CDVWKInAppBrowserCloseButtonSystemItem(void)
+{
+    if (@available(iOS 26.0, *)) {
+        return UIBarButtonSystemItemClose;
+    }
+
+    return UIBarButtonSystemItemDone;
+}
 
 #pragma mark CDVWKInAppBrowser
 
@@ -893,7 +900,7 @@ BOOL isExiting = NO;
 
     // NOTE: On iOS 26 using `UIBarButtonItem initWithBarButtonSystemItem:` gives constraint warnings,
     // which is a known UIKit bug.
-    self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:kCloseButtonSystemItem
+    self.closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:CDVWKInAppBrowserCloseButtonSystemItem()
                                                                      target:self
                                                                      action:@selector(close)];
     self.closeButton.enabled = YES;
@@ -1102,7 +1109,7 @@ BOOL isExiting = NO;
     // If a custom caption is provided, create a title-based button instead.
     self.closeButton = nil;
     // Initialize with title if set, otherwise use the system-localized Close/Done item.
-    self.closeButton = title != nil ? [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:self action:@selector(close)] : [[UIBarButtonItem alloc] initWithBarButtonSystemItem:kCloseButtonSystemItem target:self action:@selector(close)];
+    self.closeButton = title != nil ? [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:self action:@selector(close)] : [[UIBarButtonItem alloc] initWithBarButtonSystemItem:CDVWKInAppBrowserCloseButtonSystemItem() target:self action:@selector(close)];
     self.closeButton.enabled = YES;
     // If color on closebutton is requested then initialize with that that color, otherwise use initialize with default.
     self.closeButton.tintColor = colorString != nil ? [self colorFromHexString:colorString] : [UIColor colorWithRed:60.0 / 255.0 green:136.0 / 255.0 blue:230.0 / 255.0 alpha:1];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -40,6 +40,11 @@
 
 static UIBarButtonSystemItem CDVWKInAppBrowserCloseButtonSystemItem(void)
 {
+    // Since iOS 13 it's possible to use UIBarButtonSystemItemClose
+    // instead of UIBarButtonSystemItemDone which corresponds perfectly
+    // to a close button. Since UIBarButtonSystemItemClose looks akward
+    // on iOS 18 and older, because an X inside a round button is shown,
+    // instead of a text, the close button is only applied since iOS 26.
     if (@available(iOS 26.0, *)) {
         return UIBarButtonSystemItemClose;
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- XCode 26.5 complained about the macro replacement `(@available(iOS 26.0, *) ? UIBarButtonSystemItemClose : UIBarButtonSystemItemDone)` > `@available does not guard availability here; use if (@available) instead`. Since `if (@available)` cannot be easily added to the macro replacement, the macro is changed to a static function.
- Follow up of #1138
- Add note, why `UIBarButtonSystemItemClose` is used since iOS 26 and not since iOS 13
- Generated-By: GPT Codex, XCode

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
