### PR TITLE
chore!: raise minimum Cordova dependencies to the penultimate version, bump plugin major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "6.1.0-dev",
+  "version": "7.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-inappbrowser",
-      "version": "6.1.0-dev",
+      "version": "7.0.0-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cordova/eslint-config": "^6.0.1"
@@ -30,12 +30,12 @@
             "cordova-android": ">=10.0.0",
             "cordova-ios": ">=6.2.0"
           },
-          "6.1.0-dev": {
-            "cordova": ">=9.0.0",
-            "cordova-android": ">=10.0.0",
-            "cordova-ios": ">=6.2.0"
+          "7.0.0-dev": {
+            "cordova": ">=12.0.0",
+            "cordova-android": ">=14.0.0",
+            "cordova-ios": ">=7.0.0"
           },
-          "7.0.0": {
+          "8.0.0": {
             "cordova": ">100"
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "6.1.0-dev",
+  "version": "7.0.0-dev",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {
@@ -47,12 +47,12 @@
         "cordova-ios": ">=6.2.0",
         "cordova": ">=9.0.0"
       },
-      "6.1.0-dev": {
-        "cordova-android": ">=10.0.0",
-        "cordova-ios": ">=6.2.0",
-        "cordova": ">=9.0.0"
+      "7.0.0-dev": {
+        "cordova-android": ">=14.0.0",
+        "cordova-ios": ">=7.0.0",
+        "cordova": ">=12.0.0"
       },
-      "7.0.0": {
+      "8.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="6.1.0-dev">
+      version="7.0.0-dev">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "6.1.0-dev",
+  "version": "7.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -21,7 +21,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="6.1.0-dev">
+    version="7.0.0-dev">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android
- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- It's hard to test if old cordova dependencies would still work with the plugin. For e.g. if cordova-android 10 is supported by a plugin, changes would have to test against cordova-android 10, 11, etc.
- To make plugins easier to maintain it's better to keep the requirements not to wide. Also old code could be removed.
- Bump plugin version from 6.1.0-dev to 7.0.0-dev
- Changed versions: -- cordova-android from 10.0.0 to 14.0.0 -- cordova-ios from 6.2.0 to 7.0.0 -- cordova from 9.0.0 to 12.0.0

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
